### PR TITLE
tec: Allow to override the backendUrl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Configuration file
+/src/config.json

--- a/angular.json
+++ b/angular.json
@@ -39,6 +39,7 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
+              "src/config.json",
               "src/assets"
             ],
             "styles": [
@@ -112,6 +113,7 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
+              "src/config.json",
               "src/assets"
             ],
             "styles": [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -9,11 +9,17 @@ import { fas } from '@fortawesome/free-solid-svg-icons';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
+import { SettingsService } from './services/settings.service';
+
 import { HomePageComponent } from './home-page/home-page.component';
 import { LoginPageComponent } from './login-page/login-page.component';
 import { PageMenuComponent } from './page-menu/page-menu.component';
 import { TypeShowPageComponent } from './type-show-page/type-show-page.component';
 import { PageComponent } from './page/page.component';
+
+function initializeApp (settings: SettingsService) {
+  return () => settings.loadConfiguration();
+}
 
 @NgModule({
   declarations: [
@@ -31,7 +37,14 @@ import { PageComponent } from './page/page.component';
     FontAwesomeModule,
     ReactiveFormsModule,
   ],
-  providers: [],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeApp,
+      deps: [SettingsService],
+      multi: true,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { AuthService } from 'src/app/services/auth.service';
+import { SettingsService } from 'src/app/services/settings.service';
 
 import { Type } from 'src/app/interfaces/type';
 
@@ -11,18 +12,19 @@ import { Type } from 'src/app/interfaces/type';
 export class ApiService {
   constructor (
     private http: HttpClient,
+    private settingsService: SettingsService,
     private authService: AuthService,
   ) { }
 
   public login (username: string, password: string) {
-    return this.http.post('/api/v1/token', {
+    return this.http.post(this.settingsService.backendUrl + '/v1/token', {
       login: username,
       password,
     });
   }
 
   public getTypes () {
-    return this.http.get<Type[]>('/api/v1/config/types', {
+    return this.http.get<Type[]>(this.settingsService.backendUrl + '/v1/config/types', {
       headers: {
         Authorization: 'Bearer ' + this.authService.getToken(),
       },
@@ -30,7 +32,7 @@ export class ApiService {
   }
 
   public getType (id: number) {
-    return this.http.get<Type>('/api/v1/config/types/' + id, {
+    return this.http.get<Type>(this.settingsService.backendUrl + '/v1/config/types/' + id, {
       headers: {
         Authorization: 'Bearer ' + this.authService.getToken(),
       },

--- a/src/app/services/settings.service.spec.ts
+++ b/src/app/services/settings.service.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+      ],
+    });
+    service = TestBed.inject(SettingsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+
+import { map, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+interface Configuration {
+  backendUrl: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SettingsService {
+  private configuration: Configuration = {
+    backendUrl: '/api',
+  };
+
+  constructor (
+    private http: HttpClient,
+  ) { }
+
+  public async loadConfiguration () {
+    await this.http.get<Configuration>('config.json')
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          if (error.status === 404) {
+            // The configuration file is optional, so it's safe to ignore (404)
+            // error here.
+            return of(null);
+          } else {
+            return throwError(() => new Error(error.error.message));
+          }
+        }),
+      ).pipe(map((configuration: Configuration | null) => {
+        if (configuration && configuration.backendUrl) {
+          this.configuration = configuration;
+        }
+      }))
+      .toPromise();
+  }
+
+  get backendUrl () {
+    return this.configuration.backendUrl;
+  }
+}

--- a/src/config.sample.json
+++ b/src/config.sample.json
@@ -1,0 +1,3 @@
+{
+  "backendUrl": "https://backend.example.com"
+}


### PR DESCRIPTION
This commit reverts 72180f26d7f879c3786a98fbde5b48c64c38b21c, but is
more flexible: if the configuration file doesn't exist, it will fallback
to the `/api` endpoint which is handled by the proxy config.

This allows administrators to bypass an eventual proxy configuration and
gain in performance.