### PR TITLE
tec: Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Changes proposed in this pull request:
+
+-
+-
+-
+
+How to test the feature manually:
+
+1.
+2.
+3.
+
+Pull request checklist:
+
+- [ ] code is manually tested
+- [ ] tests are updated
+- [ ] commit messages are relevant
+- [ ] documentation is updated (including code comments, commit messages…)
+
+_If you think one of the item isn’t applicable to the PR, please check it
+anyway and precise `N/A` next to it._
+
+Related to #


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a file `.github/pull_request_template.md` so the PRs contents will be auto-filled for future PRs
- It is the same template as for the backend repository. I chose to not add some checklist items I had in mind (e.g. "interface works on both mobiles and big screens", "accessibility has been tested") to see how it goes with less items

How to test the feature manually:

1. create a new Git branch and commit something
2. open a pull request for this branch
3. verify the message is filled with the content of this file

Note: at the moment, you can't really test it because the file is not merged yet.

Pull request checklist:

- [x] code is manually tested N/A
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to

- https://github.com/fusionSuite/FusionSuite/issues/2
- https://github.com/fusionSuite/backend/pull/21