### PR TITLE
new: Manage organizations

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
 import { OrganizationsCreatePageComponent } from './pages/organizations/organizations-create-page/organizations-create-page.component';
+import { OrganizationsListPageComponent } from './pages/organizations/organizations-list-page/organizations-list-page.component';
 
 const routes: Routes = [
   {
@@ -23,6 +24,12 @@ const routes: Routes = [
     canActivate: [NotLoggedInGuard],
   },
 
+  {
+    path: 'organizations',
+    title: $localize `Organizations`,
+    component: OrganizationsListPageComponent,
+    canActivate: [LoggedInGuard],
+  },
   {
     path: 'organizations/new',
     title: $localize `New organization`,

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,8 +7,6 @@ import { NotLoggedInGuard } from './guards/not-logged-in.guard';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
-import { OrganizationsCreatePageComponent } from './pages/organizations/organizations-create-page/organizations-create-page.component';
-import { OrganizationsListPageComponent } from './pages/organizations/organizations-list-page/organizations-list-page.component';
 
 const routes: Routes = [
   {
@@ -26,15 +24,7 @@ const routes: Routes = [
 
   {
     path: 'organizations',
-    title: $localize `Organizations`,
-    component: OrganizationsListPageComponent,
-    canActivate: [LoggedInGuard],
-  },
-  {
-    path: 'organizations/new',
-    title: $localize `New organization`,
-    component: OrganizationsCreatePageComponent,
-    canActivate: [LoggedInGuard],
+    loadChildren: () => import('./pages/organizations/organizations.module').then(m => m.OrganizationsModule),
   },
 
   {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { NotLoggedInGuard } from './guards/not-logged-in.guard';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
+import { OrganizationsCreatePageComponent } from './pages/organizations/organizations-create-page/organizations-create-page.component';
 
 const routes: Routes = [
   {
@@ -21,6 +22,14 @@ const routes: Routes = [
     component: LoginPageComponent,
     canActivate: [NotLoggedInGuard],
   },
+
+  {
+    path: 'organizations/new',
+    title: $localize `New organization`,
+    component: OrganizationsCreatePageComponent,
+    canActivate: [LoggedInGuard],
+  },
+
   {
     path: '**',
     title: $localize `Page not found`,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,3 @@
 <router-outlet></router-outlet>
+
+<app-notifications></app-notifications>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,6 +4,8 @@ import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
+import { NotificationsComponent } from 'src/app/notifications/notifications.component';
+
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -16,6 +18,7 @@ describe('AppComponent', () => {
       ],
       declarations: [
         AppComponent,
+        NotificationsComponent,
       ],
     }).compileComponents();
   });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
 import { OrganizationsCreatePageComponent } from './pages/organizations/organizations-create-page/organizations-create-page.component';
+import { OrganizationsListPageComponent } from './pages/organizations/organizations-list-page/organizations-list-page.component';
 
 import { NotificationsComponent } from './notifications/notifications.component';
 
@@ -32,6 +33,7 @@ function initializeApp (settings: SettingsService) {
     LoginPageComponent,
     NotFoundPageComponent,
     OrganizationsCreatePageComponent,
+    OrganizationsListPageComponent,
 
     NotificationsComponent,
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,8 @@ import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
 
+import { NotificationsComponent } from './notifications/notifications.component';
+
 function initializeApp (settings: SettingsService) {
   return () => settings.loadConfiguration();
 }
@@ -28,6 +30,8 @@ function initializeApp (settings: SettingsService) {
     HomePageComponent,
     LoginPageComponent,
     NotFoundPageComponent,
+
+    NotificationsComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { SettingsService } from './services/settings.service';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
+import { OrganizationsCreatePageComponent } from './pages/organizations/organizations-create-page/organizations-create-page.component';
 
 import { NotificationsComponent } from './notifications/notifications.component';
 
@@ -30,6 +31,7 @@ function initializeApp (settings: SettingsService) {
     HomePageComponent,
     LoginPageComponent,
     NotFoundPageComponent,
+    OrganizationsCreatePageComponent,
 
     NotificationsComponent,
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,8 +16,6 @@ import { SettingsService } from './services/settings.service';
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
-import { OrganizationsCreatePageComponent } from './pages/organizations/organizations-create-page/organizations-create-page.component';
-import { OrganizationsListPageComponent } from './pages/organizations/organizations-list-page/organizations-list-page.component';
 
 import { NotificationsComponent } from './notifications/notifications.component';
 
@@ -32,8 +30,6 @@ function initializeApp (settings: SettingsService) {
     HomePageComponent,
     LoginPageComponent,
     NotFoundPageComponent,
-    OrganizationsCreatePageComponent,
-    OrganizationsListPageComponent,
 
     NotificationsComponent,
   ],

--- a/src/app/interfaces/item.ts
+++ b/src/app/interfaces/item.ts
@@ -1,0 +1,7 @@
+export interface IItem {
+  id: number;
+  id_bytype: number;
+  name: string;
+  parent_id: number;
+  treepath: string;
+}

--- a/src/app/layout/page-menu/page-menu.component.html
+++ b/src/app/layout/page-menu/page-menu.component.html
@@ -14,10 +14,16 @@
 </ul>
 
 <div class="page__nav-bottom">
-  <span class="page__nav-username">
-    <fa-icon icon="user" size="xs" [fixedWidth]="true"></fa-icon>
-    {{ displayName }}
-  </span>
+  <div class="page__nav-bottom-extend">
+    <div class="page__nav-username">
+      <fa-icon icon="user" size="xs" [fixedWidth]="true"></fa-icon>
+      {{ displayName }}
+    </div>
+
+    <div class="page__nav-organization">
+      <small>{{ organization?.name }}</small>
+    </div>
+  </div>
 
   <button (click)="logout()">
     <fa-icon icon="sign-out-alt"></fa-icon>

--- a/src/app/layout/page-menu/page-menu.component.html
+++ b/src/app/layout/page-menu/page-menu.component.html
@@ -3,6 +3,14 @@
 </a>
 
 <ul class="page__nav-container flow">
+  <li class="page__nav-item">
+    <a class="page__nav-link" [routerLink]="['/organizations']" routerLinkActive="active" ariaCurrentWhenActive="page">
+      <fa-icon icon="users" size="xs" [fixedWidth]="true"></fa-icon>
+      <ng-container i18n>
+        Organizations
+      </ng-container>
+    </a>
+  </li>
 </ul>
 
 <div class="page__nav-bottom">

--- a/src/app/layout/page-menu/page-menu.component.ts
+++ b/src/app/layout/page-menu/page-menu.component.ts
@@ -18,21 +18,27 @@ export class PageMenuComponent implements OnInit {
   }
 
   get displayName () {
+    const defaultUsername = $localize `Anonymous`;
+
     const token = this.authService.getToken();
     if (!token) {
-      return '';
+      return defaultUsername;
     }
 
     const splitToken = token.split('.');
     if (splitToken.length !== 3) {
-      return '';
+      return defaultUsername;
     }
 
     try {
       const decodedPayload = JSON.parse(atob(splitToken[1]));
-      return decodedPayload.displayname || '';
+      if (decodedPayload.firstname && decodedPayload.lastname) {
+        return decodedPayload.firstname + ' ' + decodedPayload.lastname;
+      } else {
+        return defaultUsername;
+      }
     } catch (error) {
-      return '';
+      return defaultUsername;
     }
   }
 

--- a/src/app/layout/page-menu/page-menu.component.ts
+++ b/src/app/layout/page-menu/page-menu.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { ApiService } from 'src/app/services/api.service';
 import { AuthService } from 'src/app/services/auth.service';
+
+import { IItem } from 'src/app/interfaces/item';
 
 @Component({
   selector: '[app-page-menu]',
@@ -9,36 +12,36 @@ import { AuthService } from 'src/app/services/auth.service';
   styleUrls: [],
 })
 export class PageMenuComponent implements OnInit {
+  organization: IItem|null = null;
+
   constructor (
     private authService: AuthService,
+    private apiService: ApiService,
     private router: Router,
   ) { }
 
   ngOnInit (): void {
+    this.apiService.organizationGet(this.organizationId)
+      .subscribe((result: IItem) => {
+        this.organization = result;
+      });
   }
 
   get displayName () {
-    const defaultUsername = $localize `Anonymous`;
-
-    const token = this.authService.getToken();
-    if (!token) {
-      return defaultUsername;
+    const tokenPayload = this.authService.getTokenPayload();
+    if (tokenPayload.firstname && tokenPayload.lastname) {
+      return tokenPayload.firstname + ' ' + tokenPayload.lastname;
+    } else {
+      return $localize `Anonymous`;
     }
+  }
 
-    const splitToken = token.split('.');
-    if (splitToken.length !== 3) {
-      return defaultUsername;
-    }
-
-    try {
-      const decodedPayload = JSON.parse(atob(splitToken[1]));
-      if (decodedPayload.firstname && decodedPayload.lastname) {
-        return decodedPayload.firstname + ' ' + decodedPayload.lastname;
-      } else {
-        return defaultUsername;
-      }
-    } catch (error) {
-      return defaultUsername;
+  get organizationId () {
+    const tokenPayload = this.authService.getTokenPayload();
+    if (tokenPayload.organization_id) {
+      return tokenPayload.organization_id;
+    } else {
+      return '';
     }
   }
 

--- a/src/app/notifications/notifications.component.html
+++ b/src/app/notifications/notifications.component.html
@@ -1,0 +1,11 @@
+<div class="notifications flow">
+  <p
+    *ngFor="let notification of notifications"
+    class="notifications__alert notifications__alert--{{ notification.status }}"
+    role="alert"
+  >
+    <button class="notifications__button" (click)="closeNotification(notification)">
+      {{ notification.message }}
+    </button>
+  </p>
+</div>

--- a/src/app/notifications/notifications.component.spec.ts
+++ b/src/app/notifications/notifications.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationsComponent } from './notifications.component';
+
+describe('NotificationsComponent', () => {
+  let component: NotificationsComponent;
+  let fixture: ComponentFixture<NotificationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        NotificationsComponent,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/notifications/notifications.component.ts
+++ b/src/app/notifications/notifications.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+
+import { NotificationsService, Notification } from './notifications.service';
+
+@Component({
+  selector: 'app-notifications',
+  templateUrl: './notifications.component.html',
+  styleUrls: [],
+})
+export class NotificationsComponent implements OnInit {
+  notificationsByIds: {[index: number]: Notification} = {};
+
+  constructor (
+    private notificationsService: NotificationsService,
+  ) { }
+
+  ngOnInit (): void {
+    this.notificationsService.subscribe((notification: Notification) => {
+      this.notificationsByIds[notification.id] = notification;
+
+      setTimeout(() => {
+        this.closeNotification(notification);
+      }, 7000);
+    });
+  }
+
+  closeNotification (notification: Notification) {
+    delete this.notificationsByIds[notification.id];
+  }
+
+  get notifications (): Notification[] {
+    return Object.values(this.notificationsByIds);
+  }
+}

--- a/src/app/notifications/notifications.service.spec.ts
+++ b/src/app/notifications/notifications.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NotificationsService } from './notifications.service';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('sends success notifications to subscribers', () => {
+    service.subscribe((notification) => {
+      expect(notification.message).toEqual('A successful message');
+      expect(notification.status).toEqual('success');
+    });
+
+    service.success('A successful message');
+  });
+
+  it('sends error notifications to subscribers', () => {
+    service.subscribe((notification) => {
+      expect(notification.message).toEqual('An error message');
+      expect(notification.status).toEqual('error');
+    });
+
+    service.error('An error message');
+  });
+});

--- a/src/app/notifications/notifications.service.ts
+++ b/src/app/notifications/notifications.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+
+import { Subject } from 'rxjs';
+
+export interface Notification {
+  id: number;
+  message: string;
+  status: 'error' | 'success';
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NotificationsService {
+  stream = new Subject<Notification>();
+
+  error (message: string) {
+    this.notify(message, 'error');
+  }
+
+  success (message: string) {
+    this.notify(message, 'success');
+  }
+
+  subscribe (next: (value: Notification) => void) {
+    this.stream.subscribe(next);
+  }
+
+  private notify (message: string, status: 'error' | 'success') {
+    this.stream.next({
+      message,
+      status,
+      id: Date.now(),
+    });
+  }
+}

--- a/src/app/pages/home-page/home-page.component.spec.ts
+++ b/src/app/pages/home-page/home-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
@@ -18,6 +19,7 @@ describe('HomePageComponent', () => {
       ],
       imports: [
         FontAwesomeTestingModule,
+        HttpClientTestingModule,
         LayoutModule,
         RouterTestingModule,
       ],

--- a/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html
+++ b/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html
@@ -4,7 +4,7 @@
   </header>
 
   <div class="page__inner">
-    <form [formGroup]="newOrganizationForm" (ngSubmit)="onFormSubmit()" class="flow wrapper wrapper--small">
+    <form *ngIf="organizationsLoaded && organizations.length > 0" [formGroup]="newOrganizationForm" (ngSubmit)="onFormSubmit()" class="flow wrapper wrapper--small">
       <div
         class="alert alert--error"
         role="alert"
@@ -45,9 +45,57 @@
         </div>
       </div>
 
+      <div>
+        <label for="parent-id" i18n>Parent organization</label>
+
+        <select
+          id="parent-id"
+          required
+          formControlName="parentId"
+          [attr.aria-invalid]="parentIdIsInvalid"
+          [attr.aria-errormessage]="parentIdIsInvalid ? 'parent-id-error' : null"
+        >
+          <option *ngFor="let organization of organizations" [value]="organization.id">
+            {{ formatOrganizationName(organization) }}
+          </option>
+        </select>
+
+        <div
+          class="form__error"
+          id="parent-id-error"
+          role="alert"
+          *ngIf="parentIdIsInvalid"
+        >
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <span class="sr-only" i18n>Error:</span>
+          <span *ngIf="formControls.parentId.hasError('required')" i18n>
+            The parent organization is required.
+          </span>
+        </div>
+      </div>
+
       <div class="form__actions">
         <button type="submit" class="button--primary" i18n>Create an organization</button>
       </div>
     </form>
+
+    <div *ngIf="!organizationsLoaded" class="loader flow">
+      <div class="loader__spinner"></div>
+
+      <p class="loader__message" i18n>
+        Loading of organizations…
+      </p>
+    </div>
+
+    <div *ngIf="organizationsLoaded && organizations.length === 0" class="wrapper alert alert--error" role="alert">
+      <div class="alert__title">
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <ng-container i18n>Error</ng-container>
+      </div>
+
+      <p class="alert__message" i18n>
+        You don’t have the permission to create new organizations.
+      </p>
+    </div>
   </div>
 </app-page>

--- a/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html
+++ b/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html
@@ -1,6 +1,12 @@
 <app-page i18n-page-title page-title="New organization">
-  <header class="page__header">
+  <header class="page__header flow flow--small">
     <h1 i18n>New organization</h1>
+
+    <div>
+      <a class="a--back" [routerLink]="['/organizations']" i18n>
+        Back to organizations
+      </a>
+    </div>
   </header>
 
   <div class="page__inner">

--- a/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html
+++ b/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html
@@ -1,0 +1,53 @@
+<app-page i18n-page-title page-title="New organization">
+  <header class="page__header">
+    <h1 i18n>New organization</h1>
+  </header>
+
+  <div class="page__inner">
+    <form [formGroup]="newOrganizationForm" (ngSubmit)="onFormSubmit()" class="flow wrapper wrapper--small">
+      <div
+        class="alert alert--error"
+        role="alert"
+        *ngIf="formError"
+      >
+        <div class="alert__title">
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <ng-container i18n>Error</ng-container>
+        </div>
+
+        <p class="alert__message">
+          {{ formError }}
+        </p>
+      </div>
+
+      <div>
+        <label for="name" i18n>Organization name</label>
+        <input
+          id="name"
+          type="text"
+          required
+          formControlName="name"
+          [attr.aria-invalid]="nameIsInvalid"
+          [attr.aria-errormessage]="nameIsInvalid ? 'name-error' : null"
+        >
+
+        <div
+          class="form__error"
+          id="name-error"
+          role="alert"
+          *ngIf="nameIsInvalid"
+        >
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <span class="sr-only" i18n>Error:</span>
+          <span *ngIf="formControls.name.hasError('required')" i18n>
+            The name is required.
+          </span>
+        </div>
+      </div>
+
+      <div class="form__actions">
+        <button type="submit" class="button--primary" i18n>Create an organization</button>
+      </div>
+    </form>
+  </div>
+</app-page>

--- a/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.spec.ts
+++ b/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+
+import { LayoutModule } from 'src/app/layout/layout.module';
+
+import { OrganizationsCreatePageComponent } from './organizations-create-page.component';
+
+describe('OrganizationsCreatePageComponent', () => {
+  let component: OrganizationsCreatePageComponent;
+  let fixture: ComponentFixture<OrganizationsCreatePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        OrganizationsCreatePageComponent,
+      ],
+      imports: [
+        FontAwesomeTestingModule,
+        HttpClientTestingModule,
+        LayoutModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+      ],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(OrganizationsCreatePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.ts
+++ b/src/app/pages/organizations/organizations-create-page/organizations-create-page.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { NotificationsService } from 'src/app/notifications/notifications.service';
+import { ApiService } from 'src/app/services/api.service';
+import { FormStatus } from 'src/app/utils/form-status';
+
+@Component({
+  selector: 'app-organizations-create-page',
+  templateUrl: './organizations-create-page.component.html',
+  styleUrls: [],
+})
+export class OrganizationsCreatePageComponent implements OnInit {
+  newOrganizationForm = new FormGroup({
+    name: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  formSubmitted = false;
+  formStatus: FormStatus = 'Initial';
+  formError = '';
+
+  constructor (
+    private apiService: ApiService,
+    private notificationsService: NotificationsService,
+  ) { }
+
+  ngOnInit (): void {
+  }
+
+  onFormSubmit () {
+    this.formSubmitted = true;
+
+    if (!this.canSubmit) {
+      return;
+    }
+
+    this.formStatus = 'Pending';
+    this.formError = '';
+
+    this.apiService.organizationCreate(
+      this.formControls.name.value,
+    ).pipe(
+      catchError((error: HttpErrorResponse) => {
+        this.formStatus = 'Initial';
+        this.formError = error.error.message;
+        return throwError(() => new Error(error.error.message));
+      }),
+    ).subscribe((result: any) => {
+      // Reset the form to its initial state
+      this.formStatus = 'Initial';
+      this.newOrganizationForm.reset();
+      this.formSubmitted = false;
+      this.notificationsService.success($localize `The organization has been created successfully.`);
+    });
+  }
+
+  get formControls () {
+    return this.newOrganizationForm.controls;
+  }
+
+  get canSubmit () {
+    return (
+      this.formStatus === 'Initial' &&
+      !this.nameIsInvalid
+    );
+  }
+
+  get nameIsInvalid () {
+    return this.formControls.name?.invalid && (
+      this.formControls.name?.touched ||
+      this.formSubmitted
+    );
+  }
+}

--- a/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html
+++ b/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html
@@ -17,6 +17,14 @@
           <th i18n>
             Name
           </th>
+
+          <th class="col--actions">
+            <fa-icon icon="wrench" [fixedWidth]="true"></fa-icon>
+
+            <span class="sr-only" i18n>
+              Actions
+            </span>
+          </th>
         </tr>
       </thead>
 
@@ -31,6 +39,18 @@
             </span>
 
             {{ organization.name }}
+          </td>
+
+          <td class="col--actions">
+            <form *ngIf="organization.parent_id != null" [formGroup]="deleteForm" (ngSubmit)="deleteOrganization(organization)">
+              <button type="submit" i18n-title title="Delete {{ organization.name }}">
+                <fa-icon icon="trash" [fixedWidth]="true"></fa-icon>
+
+                <span class="sr-only" i18n>
+                  Delete {{ organization.name }}
+                </span>
+              </button>
+            </form>
           </td>
         </tr>
 

--- a/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html
+++ b/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html
@@ -1,0 +1,55 @@
+<app-page i18n-page-title page-title="Organizations">
+  <header class="page__header">
+    <h1 i18n>Organizations</h1>
+  </header>
+
+  <div class="page__inner flow">
+    <a class="a--action" [routerLink]="['/organizations/new']">
+      <fa-icon icon="plus" [fixedWidth]="true"></fa-icon>
+      <ng-container i18n>
+        Create an organization
+      </ng-container>
+    </a>
+
+    <table>
+      <thead>
+        <tr>
+          <th i18n>
+            Name
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr *ngFor="let organization of organizations">
+          <td>
+            <span
+              *ngFor="let parentOrga of parentOrganizations(organization)"
+              class="text--secondary"
+            >
+              {{ parentOrga.name }} /
+            </span>
+
+            {{ organization.name }}
+          </td>
+        </tr>
+
+        <tr *ngIf="!organizationsLoaded">
+          <td colspan="2" class="loader flow">
+            <div class="loader__spinner"></div>
+
+            <p class="loader__message" i18n>
+              Loading of organizations…
+            </p>
+          </td>
+        </tr>
+
+        <tr *ngIf="organizationsLoaded && organizations.length === 0" class="tr--placeholder">
+          <td colspan="2" i18n>
+            There are no organizations to show.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</app-page>

--- a/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.spec.ts
+++ b/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+
+import { LayoutModule } from 'src/app/layout/layout.module';
+
+import { OrganizationsListPageComponent } from './organizations-list-page.component';
+
+describe('OrganizationsListPageComponent', () => {
+  let component: OrganizationsListPageComponent;
+  let fixture: ComponentFixture<OrganizationsListPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        OrganizationsListPageComponent,
+      ],
+      imports: [
+        FontAwesomeTestingModule,
+        HttpClientTestingModule,
+        LayoutModule,
+        RouterTestingModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrganizationsListPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts
+++ b/src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+
+import { ApiService } from 'src/app/services/api.service';
+import { OrganizationsSorter } from 'src/app/utils/organizations-sorter';
+
+import { IItem } from 'src/app/interfaces/item';
+
+@Component({
+  selector: 'app-organizations-list-page',
+  templateUrl: './organizations-list-page.component.html',
+  styleUrls: [],
+})
+export class OrganizationsListPageComponent implements OnInit {
+  organizationsLoaded = false;
+  organizations: IItem[] = [];
+  organizationsByIds: {[index: number]: IItem} = {};
+
+  constructor (
+    private apiService: ApiService,
+  ) { }
+
+  ngOnInit (): void {
+    this.apiService.organizationList()
+      .subscribe((result: IItem[]) => {
+        const organizationsSorter = new OrganizationsSorter();
+        this.organizations = organizationsSorter.sort(result);
+
+        result.forEach((organization) => {
+          this.organizationsByIds[organization.id] = organization;
+        });
+
+        this.organizationsLoaded = true;
+      });
+  }
+
+  parentOrganizations (organization: IItem) {
+    const parents = [];
+    let parentId: number|null = organization.parent_id;
+    while (parentId != null) {
+      const parent: IItem|null = this.organizationsByIds[parentId];
+      if (parent) {
+        parents.unshift(parent);
+        parentId = parent.parent_id;
+      } else {
+        parentId = null;
+      }
+    }
+    return parents;
+  }
+}

--- a/src/app/pages/organizations/organizations-routing.module.ts
+++ b/src/app/pages/organizations/organizations-routing.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { LoggedInGuard } from 'src/app/guards/logged-in.guard';
+
+import { OrganizationsCreatePageComponent } from './organizations-create-page/organizations-create-page.component';
+import { OrganizationsListPageComponent } from './organizations-list-page/organizations-list-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    title: $localize `Organizations`,
+    component: OrganizationsListPageComponent,
+    canActivate: [LoggedInGuard],
+  },
+  {
+    path: 'new',
+    title: $localize `New organization`,
+    component: OrganizationsCreatePageComponent,
+    canActivate: [LoggedInGuard],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class OrganizationsRoutingModule { }

--- a/src/app/pages/organizations/organizations.module.ts
+++ b/src/app/pages/organizations/organizations.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { LayoutModule } from 'src/app/layout/layout.module';
+
+import { OrganizationsRoutingModule } from './organizations-routing.module';
+
+import { OrganizationsCreatePageComponent } from './organizations-create-page/organizations-create-page.component';
+import { OrganizationsListPageComponent } from './organizations-list-page/organizations-list-page.component';
+
+@NgModule({
+  declarations: [
+    OrganizationsCreatePageComponent,
+    OrganizationsListPageComponent,
+  ],
+  imports: [
+    CommonModule,
+    FontAwesomeModule,
+    LayoutModule,
+    OrganizationsRoutingModule,
+    ReactiveFormsModule,
+  ],
+})
+export class OrganizationsModule { }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -20,4 +20,16 @@ export class ApiService {
       password,
     });
   }
+
+  public organizationCreate (name: string, parentId: number = 1) {
+    return this.http.post(this.settingsService.backendUrl + '/v1/items', {
+      name,
+      parent_id: parentId,
+      type_id: 1,
+    }, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -35,6 +35,14 @@ export class ApiService {
     });
   }
 
+  public organizationDelete (id: number) {
+    return this.http.delete(this.settingsService.backendUrl + '/v1/items/' + id, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
+
   public organizationList () {
     return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/1', {
       headers: {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -4,6 +4,8 @@ import { HttpClient } from '@angular/common/http';
 import { AuthService } from 'src/app/services/auth.service';
 import { SettingsService } from 'src/app/services/settings.service';
 
+import { IItem } from 'src/app/interfaces/item';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -21,12 +23,20 @@ export class ApiService {
     });
   }
 
-  public organizationCreate (name: string, parentId: number = 1) {
+  public organizationCreate (name: string, parentId: number) {
     return this.http.post(this.settingsService.backendUrl + '/v1/items', {
       name,
       parent_id: parentId,
       type_id: 1,
     }, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
+
+  public organizationList () {
+    return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/1', {
       headers: {
         Authorization: 'Bearer ' + this.authService.getToken(),
       },

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -43,6 +43,14 @@ export class ApiService {
     });
   }
 
+  public organizationGet (id: number) {
+    return this.http.get<IItem>(this.settingsService.backendUrl + '/v1/items/' + id, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
+
   public organizationList () {
     return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/1', {
       headers: {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -25,6 +25,24 @@ export class AuthService {
     return this.token;
   }
 
+  public getTokenPayload () {
+    const token = this.getToken();
+    if (!token) {
+      return {};
+    }
+
+    const splitToken = token.split('.');
+    if (splitToken.length !== 3) {
+      return {};
+    }
+
+    try {
+      return JSON.parse(atob(splitToken[1]));
+    } catch (error) {
+      return {};
+    }
+  }
+
   public logout () {
     this.token = '';
     window.localStorage.removeItem('authentication_token');

--- a/src/app/utils/organizations-sorter.ts
+++ b/src/app/utils/organizations-sorter.ts
@@ -1,0 +1,67 @@
+import { IItem } from 'src/app/interfaces/item';
+
+export class OrganizationsSorter {
+  sort (organizations: IItem[]): IItem[] {
+    if (!organizations) {
+      return [];
+    }
+
+    const orgasIds: number[] = [];
+    const orgasByParentId: {[index: number]: IItem[]} = {};
+
+    // Initialize the lookup objects to find organizations and their children
+    // easily.
+    organizations.forEach((orga) => {
+      orgasIds.push(orga.id);
+
+      const parentId = orga.parent_id != null ? orga.parent_id : -1;
+      if (orgasByParentId[parentId] == null) {
+        orgasByParentId[parentId] = [];
+      }
+
+      orgasByParentId[parentId].push(orga);
+    });
+
+    // Get the root organization id. We first get the list of potential parent
+    // organizations (i.e. keys of orgasByParentId). Then we get the one that
+    // doesn't exist in the list of organizations (i.e. orgasIds). It is
+    // either:
+    // - the id "-1" which corresponds to parent_id == null;
+    // - another id whose organization wasn't returned by the server because of
+    //   right accesses.
+    const rootId = Object.keys(orgasByParentId).find((id) => {
+      return !orgasIds.includes(parseInt(id, 10));
+    });
+
+    if (rootId == null) {
+      return [];
+    }
+
+    return this.getChildrenOrganizationsOf(orgasByParentId, parseInt(rootId, 10));
+  }
+
+  getChildrenOrganizationsOf (orgasByParentId: {[index: number]: IItem[]}, orgaId: number): IItem[] {
+    let sortedOrganizations: IItem[] = [];
+    const childrenOrganizations = orgasByParentId[orgaId];
+
+    if (childrenOrganizations == null) {
+      return [];
+    }
+
+    // First, sort children organizations by name
+    childrenOrganizations.sort((o1: IItem, o2: IItem) => {
+      return o1.name.localeCompare(o2.name);
+    });
+
+    // Then add the orga one by one with their own children organizations
+    childrenOrganizations.forEach((orga: IItem) => {
+      sortedOrganizations = [
+        ...sortedOrganizations,
+        orga,
+        ...this.getChildrenOrganizationsOf(orgasByParentId, orga.id),
+      ];
+    });
+
+    return sortedOrganizations;
+  }
+}

--- a/src/locales/messages.en-US.xlf
+++ b/src/locales/messages.en-US.xlf
@@ -39,7 +39,7 @@
         <target state="final">Page not found</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app-routing.module.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
@@ -65,6 +65,14 @@
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="5248717555542428023" datatype="html">
         <source>Username</source>
@@ -84,6 +92,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="86087505018521613" datatype="html">
@@ -134,6 +150,178 @@
           <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2765507593757945216" datatype="html">
+        <source>New organization</source>
+        <target state="final">New organization</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-routing.module.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1056017373280289759" datatype="html">
+        <source> Back to organizations </source>
+        <target state="final"> Back to organizations </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">6,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5243233792859835904" datatype="html">
+        <source>Organization name</source>
+        <target state="final">Organization name</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2934308315407468791" datatype="html">
+        <source> The name is required. </source>
+        <target state="final"> The name is required. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">48,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1900206707470585659" datatype="html">
+        <source>Parent organization</source>
+        <target state="final">Parent organization</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="275151463888178522" datatype="html">
+        <source> The parent organization is required. </source>
+        <target state="final"> The parent organization is required. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">77,79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7613280841129007257" datatype="html">
+        <source>Create an organization</source>
+        <target state="final">Create an organization</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2659754301310886129" datatype="html">
+        <source> Loading of organizations… </source>
+        <target state="final"> Loading of organizations… </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">91,93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">61,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1437145504608861991" datatype="html">
+        <source> You don’t have the permission to create new organizations. </source>
+        <target state="final"> You don’t have the permission to create new organizations. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">102,104</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2024202534854752781" datatype="html">
+        <source>The organization has been created successfully.</source>
+        <target state="final">The organization has been created successfully.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8539325943407755549" datatype="html">
+        <source>Organizations</source>
+        <target state="final">Organizations</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-routing.module.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6851468806127365254" datatype="html">
+        <source> Create an organization </source>
+        <target state="final"> Create an organization </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8778616811237742446" datatype="html">
+        <source> Name </source>
+        <target state="final"> Name </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4360239040231802726" datatype="html">
+        <source> Actions </source>
+        <target state="final"> Actions </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">24,26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4168485708389700387" datatype="html">
+        <source>Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/></source>
+        <target state="final">Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="860771627147100170" datatype="html">
+        <source> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </source>
+        <target state="final"> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3658263344318351354" datatype="html">
+        <source> There are no organizations to show. </source>
+        <target state="final"> There are no organizations to show. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">68,70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6733076969739703830" datatype="html">
+        <source>Do you really want to delete the organization “<x id="PH" equiv-text="organization.name"/>”?</source>
+        <target state="final">Do you really want to delete the organization “<x id="PH" equiv-text="organization.name"/>”?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3864126936025461281" datatype="html">
+        <source>The organization has been deleted successfully.</source>
+        <target state="final">The organization has been deleted successfully.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2681586038936504024" datatype="html">
         <source>Home FusionSuite</source>
         <target state="final">Home FusionSuite</target>
@@ -142,12 +330,28 @@
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5761331429036325434" datatype="html">
+        <source> Organizations </source>
+        <target state="final"> Organizations </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7507948636555938109" datatype="html">
         <source>Log out</source>
         <target state="final">Log out</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="358462242581945792" datatype="html">
+        <source>Anonymous</source>
+        <target state="final">Anonymous</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.ts</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1914592173926880968" datatype="html">

--- a/src/locales/messages.fr-FR.xlf
+++ b/src/locales/messages.fr-FR.xlf
@@ -39,7 +39,7 @@
         <target>Page non trouvée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app-routing.module.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
@@ -65,6 +65,14 @@
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="5248717555542428023" datatype="html">
         <source>Username</source>
@@ -84,6 +92,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="86087505018521613" datatype="html">
@@ -134,6 +150,178 @@
           <context context-type="linenumber">12,14</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2765507593757945216" datatype="html">
+        <source>New organization</source>
+        <target>Nouvelle organisation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-routing.module.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1056017373280289759" datatype="html">
+        <source> Back to organizations </source>
+        <target> Retour aux organisations </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">6,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5243233792859835904" datatype="html">
+        <source>Organization name</source>
+        <target>Nom de l’organisation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2934308315407468791" datatype="html">
+        <source> The name is required. </source>
+        <target> Le nom est obligatoire. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">48,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1900206707470585659" datatype="html">
+        <source>Parent organization</source>
+        <target>Organisation parente</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="275151463888178522" datatype="html">
+        <source> The parent organization is required. </source>
+        <target> L’organisation parente est obligatoire. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">77,79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7613280841129007257" datatype="html">
+        <source>Create an organization</source>
+        <target>Créer une organisation</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2659754301310886129" datatype="html">
+        <source> Loading of organizations… </source>
+        <target> Chargement des organisations… </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">91,93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">61,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1437145504608861991" datatype="html">
+        <source> You don’t have the permission to create new organizations. </source>
+        <target> Vous n’avez pas la permission de créer de nouvelles organisations. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">102,104</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2024202534854752781" datatype="html">
+        <source>The organization has been created successfully.</source>
+        <target>L’organisation a été créée correctement.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8539325943407755549" datatype="html">
+        <source>Organizations</source>
+        <target>Organisations</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-routing.module.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6851468806127365254" datatype="html">
+        <source> Create an organization </source>
+        <target> Créer une organisation </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8778616811237742446" datatype="html">
+        <source> Name </source>
+        <target> Nom </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4360239040231802726" datatype="html">
+        <source> Actions </source>
+        <target> Actions </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">24,26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4168485708389700387" datatype="html">
+        <source>Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/></source>
+        <target>Supprimer <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="860771627147100170" datatype="html">
+        <source> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </source>
+        <target> Supprimer <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3658263344318351354" datatype="html">
+        <source> There are no organizations to show. </source>
+        <target> Il n’y a aucune organisation à afficher. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">68,70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6733076969739703830" datatype="html">
+        <source>Do you really want to delete the organization “<x id="PH" equiv-text="organization.name"/>”?</source>
+        <target>Êtes-vous sûr de vouloir supprimer l’organisation « <x id="PH" equiv-text="organization.name"/> » ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3864126936025461281" datatype="html">
+        <source>The organization has been deleted successfully.</source>
+        <target>L’organisation a été supprimée correctement.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
+          <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2681586038936504024" datatype="html">
         <source>Home FusionSuite</source>
         <target>Accueil FusionSuite</target>
@@ -142,12 +330,28 @@
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5761331429036325434" datatype="html">
+        <source> Organizations </source>
+        <target> Organisations </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7507948636555938109" datatype="html">
         <source>Log out</source>
         <target>Se déconnecter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="358462242581945792" datatype="html">
+        <source>Anonymous</source>
+        <target>Anonyme</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.ts</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1914592173926880968" datatype="html">

--- a/src/locales/messages.xlf
+++ b/src/locales/messages.xlf
@@ -36,7 +36,7 @@
         <source>Page not found</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app-routing.module.ts</context>
-          <context context-type="linenumber">26</context>
+          <context context-type="linenumber">32</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
@@ -54,11 +54,25 @@
           <context context-type="linenumber">2</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5761331429036325434" datatype="html">
+        <source> Organizations </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7507948636555938109" datatype="html">
         <source>Log out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="358462242581945792" datatype="html">
+        <source>Anonymous</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.ts</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1914592173926880968" datatype="html">
@@ -81,6 +95,14 @@
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">15</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="5248717555542428023" datatype="html">
         <source>Username</source>
@@ -98,6 +120,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">66</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="86087505018521613" datatype="html">
@@ -140,6 +170,159 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
           <context context-type="linenumber">12,14</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2765507593757945216" datatype="html">
+        <source>New organization</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-routing.module.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1056017373280289759" datatype="html">
+        <source> Back to organizations </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">6,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5243233792859835904" datatype="html">
+        <source>Organization name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2934308315407468791" datatype="html">
+        <source> The name is required. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">48,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1900206707470585659" datatype="html">
+        <source>Parent organization</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="275151463888178522" datatype="html">
+        <source> The parent organization is required. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">77,79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7613280841129007257" datatype="html">
+        <source>Create an organization</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2659754301310886129" datatype="html">
+        <source> Loading of organizations… </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">91,93</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">61,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1437145504608861991" datatype="html">
+        <source> You don’t have the permission to create new organizations. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
+          <context context-type="linenumber">102,104</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2024202534854752781" datatype="html">
+        <source>The organization has been created successfully.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.ts</context>
+          <context context-type="linenumber">86</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8539325943407755549" datatype="html">
+        <source>Organizations</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-routing.module.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6851468806127365254" datatype="html">
+        <source> Create an organization </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8778616811237742446" datatype="html">
+        <source> Name </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4360239040231802726" datatype="html">
+        <source> Actions </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">24,26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4168485708389700387" datatype="html">
+        <source>Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="860771627147100170" datatype="html">
+        <source> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">49,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3658263344318351354" datatype="html">
+        <source> There are no organizations to show. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
+          <context context-type="linenumber">68,70</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6733076969739703830" datatype="html">
+        <source>Do you really want to delete the organization “<x id="PH" equiv-text="organization.name"/>”?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3864126936025461281" datatype="html">
+        <source>The organization has been deleted successfully.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/theme/anchors.scss
+++ b/src/theme/anchors.scss
@@ -1,0 +1,26 @@
+a {
+  color: var(--color-primary11);
+}
+
+.a--action {
+  padding: 0.3rem;
+
+  text-decoration: none;
+
+  border: 0.1em solid currentcolor;
+  border-radius: 5px;
+
+  transition: background-color 0.2s ease-in-out;
+
+  &:hover {
+    background-color: var(--color-primary3);
+  }
+}
+
+.a--back {
+  padding: 0.3rem;
+
+  &::before {
+    content: "← ";
+  }
+}

--- a/src/theme/forms.scss
+++ b/src/theme/forms.scss
@@ -48,6 +48,56 @@ input {
   }
 }
 
+select {
+  width: 100%;
+  padding: 0.2rem;
+
+  color: inherit;
+  font-family: inherit;
+  font-size: 1em;
+  text-overflow: ellipsis;
+
+  background-color: var(--color-grey3);
+  border: none;
+  border-bottom: 2px solid var(--color-primary9);
+
+  transition:
+    background-color 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
+
+  @media (min-width: 800px) {
+    width: auto;
+    min-width: 50%;
+  }
+
+  &:hover {
+    background-color: var(--color-grey4);
+    border-color: var(--color-primary10);
+  }
+
+  &:focus {
+    color: var(--color-primary12);
+
+    background-color: var(--color-primary5);
+  }
+
+  &[aria-invalid="true"] {
+    color: var(--color-error12);
+
+    background-color: var(--color-error3);
+    border-color: var(--color-error9);
+
+    &:hover {
+      background-color: var(--color-error4);
+      border-color: var(--color-error10);
+    }
+
+    &:focus {
+      background-color: var(--color-error5);
+    }
+  }
+}
+
 .form__actions {
   display: flex;
 

--- a/src/theme/loaders.scss
+++ b/src/theme/loaders.scss
@@ -1,0 +1,33 @@
+.loader {
+  .loader__message {
+    color: var(--color-grey11);
+    font-size: 1.1rem;
+    font-style: italic;
+    text-align: center;
+  }
+
+  .loader__spinner {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-right: auto;
+    margin-left: auto;
+
+    background-color: var(--color-primary9);
+    border-radius: 100%;
+
+    animation: sk-scaleout 1s infinite ease-in-out;
+  }
+}
+
+@keyframes sk-scaleout {
+  0% {
+    transform: scale(0);
+  }
+
+  100% {
+    opacity: 0;
+
+    transform: scale(1);
+  }
+}

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -4,6 +4,7 @@
 @import "alerts";
 @import "buttons";
 @import "forms";
+@import "loaders";
 @import "pages";
 @import "notifications";
 

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -2,11 +2,14 @@
 @import "utilities/flow";
 @import "utilities/wrapper";
 @import "alerts";
+@import "anchors";
 @import "buttons";
 @import "forms";
 @import "loaders";
 @import "pages";
 @import "notifications";
+@import "tables";
+@import "text";
 
 *,
 *::before,

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -4,6 +4,7 @@
 @import "buttons";
 @import "forms";
 @import "pages";
+@import "notifications";
 
 *,
 *::before,
@@ -52,4 +53,8 @@ body {
 
   width: 1px;
   height: 1px;
+}
+
+p {
+  margin: 0;
 }

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -1,5 +1,6 @@
 @import "variables/colors";
 @import "utilities/flow";
+@import "utilities/wrapper";
 @import "alerts";
 @import "buttons";
 @import "forms";

--- a/src/theme/notifications.scss
+++ b/src/theme/notifications.scss
@@ -1,0 +1,48 @@
+.notifications {
+  position: fixed;
+  z-index: 999;
+  top: 1rem;
+  right: 1rem;
+
+  width: 300px;
+}
+
+.notifications__button {
+  display: block;
+  width: 100%;
+  padding: 1rem;
+
+  text-align: left;
+
+  box-shadow: 1px 2px 2px var(--color-grey8);
+  border: none;
+  border-radius: 10px;
+
+  .notifications__alert--error & {
+    color: var(--color-error12);
+
+    background-color: var(--color-error4);
+  }
+
+  .notifications__alert--success & {
+    color: var(--color-success12);
+
+    background-color: var(--color-success4);
+  }
+
+  .notifications__alert--error &:hover {
+    background-color: var(--color-error5);
+  }
+
+  .notifications__alert--error &:active {
+    background-color: var(--color-error6);
+  }
+
+  .notifications__alert--success &:hover {
+    background-color: var(--color-success5);
+  }
+
+  .notifications__alert--success &:active {
+    background-color: var(--color-success6);
+  }
+}

--- a/src/theme/pages.scss
+++ b/src/theme/pages.scss
@@ -19,7 +19,7 @@
   overflow: auto;
 
   width: 275px;
-  max-height: calc(100vh - 3rem);
+  max-height: calc(100vh - 3.5rem);
   margin-bottom: 3rem;
   padding: 1rem 0.5rem;
 
@@ -79,7 +79,7 @@
 
   display: flex;
   width: 275px;
-  height: 3rem;
+  height: 3.5rem;
   padding: 0.25rem 0.5rem;
 
   align-items: center;
@@ -88,14 +88,18 @@
   box-shadow: 4px 0 8px rgb(0 0 0 / 25%);
 }
 
-.page__nav-username {
+.page__nav-bottom-extend {
   overflow: hidden;
 
   flex: 1;
 
-  text-overflow: ellipsis;
+  > * {
+    overflow: hidden;
 
-  white-space: nowrap;
+    text-overflow: ellipsis;
+
+    white-space: nowrap;
+  }
 }
 
 .page__content {

--- a/src/theme/tables.scss
+++ b/src/theme/tables.scss
@@ -16,6 +16,12 @@ td {
   padding: 0.5rem;
 
   font-size: 0.9rem;
+
+  &.col--actions {
+    width: 5rem;
+
+    text-align: center;
+  }
 }
 
 tr:nth-child(even) {

--- a/src/theme/tables.scss
+++ b/src/theme/tables.scss
@@ -1,0 +1,37 @@
+table {
+  width: 100%;
+
+  border-collapse: collapse;
+}
+
+thead {
+  text-align: left;
+
+  background-color: var(--color-grey3);
+  border-bottom: 1px solid var(--color-grey6);
+}
+
+th,
+td {
+  padding: 0.5rem;
+
+  font-size: 0.9rem;
+}
+
+tr:nth-child(even) {
+  background-color: var(--color-grey2);
+}
+
+tr.tr--placeholder {
+  background-color: var(--color-grey2);
+
+  td {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+
+    color: var(--color-grey11);
+    font-size: 1.1rem;
+    font-style: italic;
+    text-align: center;
+  }
+}

--- a/src/theme/text.scss
+++ b/src/theme/text.scss
@@ -1,0 +1,3 @@
+.text--secondary {
+  color: var(--color-grey11);
+}

--- a/src/theme/utilities/flow.scss
+++ b/src/theme/utilities/flow.scss
@@ -1,3 +1,9 @@
-.flow > * + * {
-  margin-top: var(--flow-space, 1em);
+.flow {
+  > * + * {
+    margin-top: 1rem;
+  }
+
+  &.flow--small > * + * {
+    margin-top: 0.5rem;
+  }
 }

--- a/src/theme/utilities/wrapper.scss
+++ b/src/theme/utilities/wrapper.scss
@@ -1,0 +1,13 @@
+.wrapper {
+  max-width: 1000px;
+  margin-right: auto;
+  margin-left: auto;
+
+  &.wrapper--small {
+    max-width: 800px;
+  }
+
+  &.wrapper--large {
+    max-width: 1200px;
+  }
+}

--- a/src/theme/variables/colors.scss
+++ b/src/theme/variables/colors.scss
@@ -3,6 +3,19 @@
   // see https://www.radix-ui.com/docs/colors/palette-composition/understanding-the-scale
 
   // Radix colors
+  --green1: hsl(136deg 50% 98.9%);
+  --green2: hsl(138deg 62.5% 96.9%);
+  --green3: hsl(139deg 55.2% 94.5%);
+  --green4: hsl(140deg 48.7% 91%);
+  --green5: hsl(141deg 43.7% 86%);
+  --green6: hsl(143deg 40.3% 79%);
+  --green7: hsl(146deg 38.5% 69%);
+  --green8: hsl(151deg 40.2% 54.1%);
+  --green9: hsl(151deg 55% 41.5%);
+  --green10: hsl(152deg 57.5% 37.6%);
+  --green11: hsl(153deg 67% 28.5%);
+  --green12: hsl(155deg 40% 14%);
+
   --red1: hsl(359deg 100% 99.4%);
   --red2: hsl(359deg 100% 98.6%);
   --red3: hsl(360deg 100% 96.8%);
@@ -51,38 +64,46 @@
   --color-grey2: var(--slate2);
   --color-primary1: var(--sky1);
   --color-primary2: var(--sky2);
+  --color-success1: var(--green1);
+  --color-success2: var(--green2);
 
   // Component backgrounds (+1 for call-to-action components)
   // normal states
   --color-error3: var(--red3);
   --color-grey3: var(--slate3);
   --color-primary3: var(--sky3);
+  --color-success3: var(--green3);
 
   // hover states
   --color-error4: var(--red4);
   --color-grey4: var(--slate4);
   --color-primary4: var(--sky4);
+  --color-success4: var(--green4);
 
   // pressed or selected states
   --color-error5: var(--red5);
   --color-grey5: var(--slate5);
   --color-primary5: var(--sky5);
+  --color-success5: var(--green5);
 
   // Borders
   // subtle borders for non-interactive components
   --color-error6: var(--red6);
   --color-grey6: var(--slate6);
   --color-primary6: var(--sky6);
+  --color-success6: var(--green6);
 
   // borders for interactive components, focus rings
   --color-error7: var(--red7);
   --color-grey7: var(--slate7);
   --color-primary7: var(--sky7);
+  --color-success7: var(--green7);
 
   // border for interactive components in hover state
   --color-error8: var(--red8);
   --color-grey8: var(--slate8);
   --color-primary8: var(--sky8);
+  --color-success8: var(--green8);
 
   // Solid backgrounds
   // Main backgrounds in normal state (e.g. header backgrounds, coloured
@@ -90,20 +111,24 @@
   --color-error9: var(--red9);
   --color-grey9: var(--slate9);
   --color-primary9: var(--sky9);
+  --color-success9: var(--green9);
 
   // Main backgrounds in hover state
   --color-error10: var(--red10);
   --color-grey10: var(--slate10);
   --color-primary10: var(--sky10);
+  --color-success10: var(--green10);
 
   // Text
   // low-contrast text
   --color-error11: var(--red11);
   --color-grey11: var(--slate11);
   --color-primary11: var(--sky11);
+  --color-success11: var(--green11);
 
   // high-contrast text
   --color-error12: var(--red12);
   --color-grey12: var(--slate12);
   --color-primary12: var(--sky12);
+  --color-success12: var(--green12);
 }


### PR DESCRIPTION
**This PR must be merged after https://github.com/fusionSuite/backend/pull/18.**

This PR can be reviewed commit by commit.

Changes proposed in this pull request:

- Add a notification center to display notifications to user (successes and errors)
- Allow to create organizations (name & parent organization)
- Add a page to list the existing organizations
- Allow to delete organizations (with confirmation)
- Display username and its organization in the sidemenu

Few known limitations (that I think are ok for the moment):

- organizations are reloaded each time we go to the list and create pages
- confirmations are handled by `window.confirm()` (i.e. browser-native confirmation dialog)
- permissions of the user are not checked (I don't think it's possible for now)
- it is not possible to update an organization name
- "Organizations" are directly accessible via the sidemenu, but it should move elsewhere in the future
- it is not correctly tested, because it's very difficult with the Angular test suite. I started a different branch to explore how to test with Cypress https://github.com/fusionSuite/frontend/pull/28

List of organizations:

![Capture d’écran 2022-08-17 à 09 34 32](https://user-images.githubusercontent.com/107053378/185061455-c456618e-8d73-4291-883f-84fe6206582f.png)

Creation of an organization:

![Capture d’écran 2022-08-17 à 09 34 40](https://user-images.githubusercontent.com/107053378/185061489-0634b9c1-19b8-4faf-bee4-673a869cca59.png)

How to test the feature manually:

1. make sure that your backend is up-to-date with https://github.com/fusionSuite/backend/pull/18
2. login & click on "Organizations"
3. a first "My organization" should be displayed
4. click on "Create an organization" & create few organizations with different parents
5. go back to "Organizations" and verify that your organizations have been created and are attached to the correct parents
6. delete an organization and verify it's well deleted

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated → see https://github.com/fusionSuite/frontend/pull/28
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to:

- https://github.com/fusionSuite/FusionSuite/issues/41
- https://github.com/fusionSuite/backend/pull/18
- https://github.com/fusionSuite/frontend/pull/28
