### PR TITLE
When use `make start`, add argument to the command to use the proxy.c…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --browsers ChromeHeadless --code-coverage --watch=false"


### PR DESCRIPTION
…onf.json file for backend config.

Changes proposed in this pull request:

- when use make start, use the proxy configuration for the specific backend URL

How to test the feature manually:

1. modify target in proxy.conf.json file
2. run `make start`
3. the frontend works with customized backend URL

Pull request checklist:

- [x] code is manually tested
- [x] **N/A** tests are updated 
- [x] commit messages are relevant
- [x] **N/A** documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
