### PR TITLE
fix: Load types in Settings only when connected

### DIFF
--- a/src/app/pages/login-page/login-page.component.ts
+++ b/src/app/pages/login-page/login-page.component.ts
@@ -8,6 +8,7 @@ import { catchError } from 'rxjs/operators';
 
 import { ApiService } from 'src/app/services/api.service';
 import { AuthService } from 'src/app/services/auth.service';
+import { SettingsService } from 'src/app/services/settings.service';
 import { FormStatus } from 'src/app/utils/form-status';
 
 @Component({
@@ -34,6 +35,7 @@ export class LoginPageComponent implements OnInit {
   constructor (
     private apiService: ApiService,
     private authService: AuthService,
+    private settingsService: SettingsService,
     private router: Router,
   ) { }
 
@@ -60,9 +62,12 @@ export class LoginPageComponent implements OnInit {
         return throwError(() => new Error(error.error.message));
       }),
     )
-      .subscribe((result: any) => {
+      .subscribe(async (result: any) => {
         // Save the token to use it later
         this.authService.login(result.token);
+
+        // Load types in settings so we'll be able to manage items
+        await this.settingsService.loadTypes();
 
         // Reset the form to its initial state
         this.formStatus = 'Initial';

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -50,7 +50,13 @@ export class SettingsService {
       }))
       .toPromise();
 
-    await this.http.get<IType[]>(this.configuration.backendUrl + '/v1/config/types', {
+    if (this.authService.isLoggedIn()) {
+      await this.loadTypes();
+    }
+  }
+
+  public loadTypes () {
+    return this.http.get<IType[]>(this.configuration.backendUrl + '/v1/config/types', {
       headers: {
         Authorization: 'Bearer ' + this.authService.getToken(),
       },


### PR DESCRIPTION
Changes proposed in this pull request:

- load types only if connected during the application initialization
- load types after a successful login

How to test the feature manually:

1. Go to the login page, make sure to refresh the page: the login form should be accessible
2. Log in, go to the organizations tab and check that organizations are loaded
3. Refresh the page, check that organizations are loaded

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated N/A
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to https://github.com/fusionSuite/frontend/pull/30
