### PR TITLE
new: Manage users

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -28,6 +28,11 @@ const routes: Routes = [
   },
 
   {
+    path: 'users',
+    loadChildren: () => import('./pages/users/users.module').then(m => m.UsersModule),
+  },
+
+  {
     path: '**',
     title: $localize `Page not found`,
     component: NotFoundPageComponent,

--- a/src/app/interfaces/item.ts
+++ b/src/app/interfaces/item.ts
@@ -1,7 +1,14 @@
+import { IProperty } from './property';
+
 export interface IItem {
   id: number;
   id_bytype: number;
   name: string;
   parent_id: number;
   treepath: string;
+  organization: {
+    id: number;
+    name: string;
+  };
+  properties: IProperty[];
 }

--- a/src/app/layout/page-menu/page-menu.component.html
+++ b/src/app/layout/page-menu/page-menu.component.html
@@ -2,12 +2,21 @@
   <img i18n-alt alt="Home FusionSuite" src="assets/logo.png" width="200">
 </a>
 
-<ul class="page__nav-container flow">
+<ul class="page__nav-container flow flow--small">
   <li class="page__nav-item">
     <a class="page__nav-link" [routerLink]="['/organizations']" routerLinkActive="active" ariaCurrentWhenActive="page">
       <fa-icon icon="users" size="xs" [fixedWidth]="true"></fa-icon>
       <ng-container i18n>
         Organizations
+      </ng-container>
+    </a>
+  </li>
+
+  <li class="page__nav-item">
+    <a class="page__nav-link" [routerLink]="['/users']" routerLinkActive="active" ariaCurrentWhenActive="page">
+      <fa-icon icon="user" size="xs" [fixedWidth]="true"></fa-icon>
+      <ng-container i18n>
+        Users
       </ng-container>
     </a>
   </li>

--- a/src/app/models/item.ts
+++ b/src/app/models/item.ts
@@ -4,11 +4,13 @@ import { IProperty } from 'src/app/interfaces/property';
 export class Item {
   item: IItem;
 
+  id: number;
   name: string;
   propertiesIndexedByInternalname: {[key: string]: IProperty} = {};
 
   constructor (item: IItem) {
     this.item = item;
+    this.id = item.id;
     this.name = item.name;
     this.item.properties.forEach((property) => {
       this.propertiesIndexedByInternalname[property.internalname] = property;

--- a/src/app/models/item.ts
+++ b/src/app/models/item.ts
@@ -1,0 +1,29 @@
+import { IItem } from 'src/app/interfaces/item';
+import { IProperty } from 'src/app/interfaces/property';
+
+export class Item {
+  item: IItem;
+
+  name: string;
+  propertiesIndexedByInternalname: {[key: string]: IProperty} = {};
+
+  constructor (item: IItem) {
+    this.item = item;
+    this.name = item.name;
+    this.item.properties.forEach((property) => {
+      this.propertiesIndexedByInternalname[property.internalname] = property;
+    });
+  }
+
+  getPropValueByInternalname (internalname: string, defaultValue: any = null) {
+    if (this.propertiesIndexedByInternalname[internalname]) {
+      return this.propertiesIndexedByInternalname[internalname].value;
+    } else {
+      return defaultValue;
+    }
+  }
+
+  get organizationName () {
+    return this.item.organization.name;
+  }
+}

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -1,0 +1,20 @@
+import { Item } from './item';
+
+export class User extends Item {
+  get firstname () {
+    return this.getPropValueByInternalname('userfirstname', '');
+  }
+
+  get lastname () {
+    return this.getPropValueByInternalname('userlastname', '');
+  }
+
+  get displayName () {
+    const displayName = this.firstname + ' ' + this.lastname;
+    if (displayName !== ' ') {
+      return displayName;
+    } else {
+      return '';
+    }
+  }
+}

--- a/src/app/pages/users/users-create-page/users-create-page.component.html
+++ b/src/app/pages/users/users-create-page/users-create-page.component.html
@@ -36,6 +36,7 @@
             id="firstname"
             type="text"
             formControlName="firstname"
+            (input)="fillUsername()"
           >
         </div>
 
@@ -48,6 +49,7 @@
             id="lastname"
             type="text"
             formControlName="lastname"
+            (input)="fillUsername()"
           >
         </div>
       </div>

--- a/src/app/pages/users/users-create-page/users-create-page.component.html
+++ b/src/app/pages/users/users-create-page/users-create-page.component.html
@@ -1,6 +1,12 @@
 <app-page i18n-page-title page-title="New user">
   <header class="page__header flow flow--small">
     <h1 i18n>New user</h1>
+
+    <div>
+      <a class="a--back" [routerLink]="['/users']" i18n>
+        Back to users
+      </a>
+    </div>
   </header>
 
   <div class="page__inner">

--- a/src/app/pages/users/users-create-page/users-create-page.component.html
+++ b/src/app/pages/users/users-create-page/users-create-page.component.html
@@ -1,0 +1,127 @@
+<app-page i18n-page-title page-title="New user">
+  <header class="page__header flow flow--small">
+    <h1 i18n>New user</h1>
+  </header>
+
+  <div class="page__inner">
+    <form *ngIf="organizationsLoaded && organizations.length > 0" [formGroup]="newUserForm" (ngSubmit)="onFormSubmit()" class="flow wrapper wrapper--small">
+      <div
+        class="alert alert--error"
+        role="alert"
+        *ngIf="formError"
+      >
+        <div class="alert__title">
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <ng-container i18n>Error</ng-container>
+        </div>
+
+        <p class="alert__message">
+          {{ formError }}
+        </p>
+      </div>
+
+      <div class="cols">
+        <div>
+          <label for="firstname">
+            <ng-container i18n>First name</ng-container>
+            <span class="text--secondary" i18n> (optional)</span>
+          </label>
+          <input
+            id="firstname"
+            type="text"
+            formControlName="firstname"
+          >
+        </div>
+
+        <div>
+          <label for="lastname">
+            <ng-container i18n>Last name</ng-container>
+            <span class="text--secondary" i18n> (optional)</span>
+          </label>
+          <input
+            id="lastname"
+            type="text"
+            formControlName="lastname"
+          >
+        </div>
+      </div>
+
+      <div>
+        <label for="name" i18n>Username</label>
+        <input
+          id="name"
+          type="text"
+          required
+          formControlName="name"
+          [attr.aria-invalid]="nameIsInvalid"
+          [attr.aria-errormessage]="nameIsInvalid ? 'name-error' : null"
+        >
+
+        <div
+          class="form__error"
+          id="name-error"
+          role="alert"
+          *ngIf="nameIsInvalid"
+        >
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <span class="sr-only" i18n>Error:</span>
+          <span *ngIf="formControls.name.hasError('required')" i18n>
+            The name is required.
+          </span>
+        </div>
+      </div>
+
+      <div>
+        <label for="organization-id" i18n>Main organization</label>
+
+        <select
+          id="organization-id"
+          required
+          formControlName="organizationId"
+          [attr.aria-invalid]="organizationIdIsInvalid"
+          [attr.aria-errormessage]="organizationIdIsInvalid ? 'organization-id-error' : null"
+        >
+          <option *ngFor="let organization of organizations" [value]="organization.id">
+            {{ formatOrganizationName(organization) }}
+          </option>
+        </select>
+
+        <div
+          class="form__error"
+          id="organization-id-error"
+          role="alert"
+          *ngIf="organizationIdIsInvalid"
+        >
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <span class="sr-only" i18n>Error:</span>
+          <span *ngIf="formControls.organizationId.hasError('required')" i18n>
+            The organization is required.
+          </span>
+        </div>
+      </div>
+
+      <div class="form__actions">
+        <button type="submit" class="button--primary" i18n>Create a user</button>
+      </div>
+    </form>
+
+    <div *ngIf="!organizationsLoaded" class="loader flow">
+      <div class="loader__spinner"></div>
+
+      <p class="loader__message" i18n>
+        Loading of organizations…
+      </p>
+    </div>
+
+    <div *ngIf="organizationsLoaded && organizations.length === 0" class="wrapper alert alert--error" role="alert">
+      <div class="alert__title">
+          <fa-icon icon="exclamation-circle"></fa-icon>
+          <ng-container i18n>Error</ng-container>
+      </div>
+
+      <p class="alert__message" i18n>
+        You don’t have the permission to create new users.
+      </p>
+    </div>
+  </div>
+</app-page>

--- a/src/app/pages/users/users-create-page/users-create-page.component.spec.ts
+++ b/src/app/pages/users/users-create-page/users-create-page.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+
+import { LayoutModule } from 'src/app/layout/layout.module';
+
+import { UsersCreatePageComponent } from './users-create-page.component';
+
+describe('UsersCreatePageComponent', () => {
+  let component: UsersCreatePageComponent;
+  let fixture: ComponentFixture<UsersCreatePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        UsersCreatePageComponent,
+      ],
+      imports: [
+        FontAwesomeTestingModule,
+        HttpClientTestingModule,
+        LayoutModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+      ],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(UsersCreatePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/users/users-create-page/users-create-page.component.ts
+++ b/src/app/pages/users/users-create-page/users-create-page.component.ts
@@ -1,0 +1,134 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { NotificationsService } from 'src/app/notifications/notifications.service';
+import { ApiService } from 'src/app/services/api.service';
+import { FormStatus } from 'src/app/utils/form-status';
+import { OrganizationsSorter } from 'src/app/utils/organizations-sorter';
+
+import { IItem } from 'src/app/interfaces/item';
+
+@Component({
+  selector: 'app-users-create-page',
+  templateUrl: './users-create-page.component.html',
+  styleUrls: [],
+})
+export class UsersCreatePageComponent implements OnInit {
+  organizationsLoaded = false;
+  organizations: IItem[] = [];
+
+  newUserForm = new FormGroup({
+    name: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+
+    firstname: new FormControl('', {
+      nonNullable: true,
+    }),
+
+    lastname: new FormControl('', {
+      nonNullable: true,
+    }),
+
+    organizationId: new FormControl('1', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  formSubmitted = false;
+  formStatus: FormStatus = 'Initial';
+  formError = '';
+
+  constructor (
+    private apiService: ApiService,
+    private notificationsService: NotificationsService,
+  ) { }
+
+  ngOnInit (): void {
+    this.loadOrganizations();
+  }
+
+  loadOrganizations () {
+    this.apiService.organizationList()
+      .subscribe((result: IItem[]) => {
+        const organizationsSorter = new OrganizationsSorter();
+        this.organizations = organizationsSorter.sort(result);
+
+        if (this.organizations.length > 0) {
+          this.formControls.organizationId.setValue(String(this.organizations[0].id));
+        }
+
+        this.organizationsLoaded = true;
+      });
+  }
+
+  onFormSubmit () {
+    this.formSubmitted = true;
+
+    if (!this.canSubmit) {
+      return;
+    }
+
+    this.formStatus = 'Pending';
+    this.formError = '';
+
+    this.apiService.userCreate(
+      this.formControls.name.value,
+      this.formControls.firstname.value,
+      this.formControls.lastname.value,
+      parseInt(this.formControls.organizationId.value, 10),
+    ).pipe(
+      catchError((error: HttpErrorResponse) => {
+        this.formStatus = 'Initial';
+        this.formError = error.error.message;
+        return throwError(() => new Error(error.error.message));
+      }),
+    ).subscribe((result: any) => {
+      // Reset the form to its initial state
+      this.formStatus = 'Initial';
+      this.newUserForm.reset();
+      this.formSubmitted = false;
+      this.notificationsService.success($localize `The user has been created successfully.`);
+    });
+  }
+
+  get formControls () {
+    return this.newUserForm.controls;
+  }
+
+  get canSubmit () {
+    return (
+      this.formStatus === 'Initial' &&
+      !this.nameIsInvalid &&
+      !this.organizationIdIsInvalid
+    );
+  }
+
+  get nameIsInvalid () {
+    return this.formControls.name?.invalid && (
+      this.formControls.name?.touched ||
+      this.formSubmitted
+    );
+  }
+
+  get organizationIdIsInvalid () {
+    return this.formControls.organizationId?.invalid && (
+      this.formControls.organizationId?.touched ||
+      this.formSubmitted
+    );
+  }
+
+  formatOrganizationName (orga: IItem) {
+    // treepath length is a multiple of 4
+    const baseTreeDepth = this.organizations[0].treepath.length;
+    const treeDepth = orga.treepath.length - baseTreeDepth;
+    // prepend *non-breakable* spaces to the organization name
+    return ' '.repeat(treeDepth) + orga.name;
+  }
+}

--- a/src/app/pages/users/users-create-page/users-create-page.component.ts
+++ b/src/app/pages/users/users-create-page/users-create-page.component.ts
@@ -124,6 +124,13 @@ export class UsersCreatePageComponent implements OnInit {
     );
   }
 
+  fillUsername () {
+    const firstname = this.formControls.firstname.value.toLocaleLowerCase();
+    const lastname = this.formControls.lastname.value.toLocaleLowerCase();
+    const username = (firstname + ' ' + lastname).trim().replace(' ', '-');
+    this.formControls.name.setValue(username);
+  }
+
   formatOrganizationName (orga: IItem) {
     // treepath length is a multiple of 4
     const baseTreeDepth = this.organizations[0].treepath.length;

--- a/src/app/pages/users/users-list-page/users-list-page.component.html
+++ b/src/app/pages/users/users-list-page/users-list-page.component.html
@@ -1,0 +1,59 @@
+<app-page i18n-page-title page-title="Users">
+  <header class="page__header">
+    <h1 i18n>Users</h1>
+  </header>
+
+  <div class="page__inner flow">
+    <a class="a--action" [routerLink]="['/users/new']">
+      <fa-icon icon="plus" [fixedWidth]="true"></fa-icon>
+      <ng-container i18n>
+        Create a user
+      </ng-container>
+    </a>
+
+    <table>
+      <thead>
+        <tr>
+          <th i18n>
+            Name
+          </th>
+
+          <th i18n>
+            Organization
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr *ngFor="let user of users">
+          <td>
+            {{ user.name }}
+            <span *ngIf="user.displayName" class="text--secondary">
+              ({{ user.displayName }})
+            </span>
+          </td>
+
+          <td>
+            {{ user.organizationName }}
+          </td>
+        </tr>
+
+        <tr *ngIf="!usersLoaded">
+          <td colspan="2" class="loader flow">
+            <div class="loader__spinner"></div>
+
+            <p class="loader__message" i18n>
+              Loading of users…
+            </p>
+          </td>
+        </tr>
+
+        <tr *ngIf="usersLoaded && users.length === 0" class="tr--placeholder">
+          <td colspan="2" i18n>
+            There are no users to show.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</app-page>

--- a/src/app/pages/users/users-list-page/users-list-page.component.html
+++ b/src/app/pages/users/users-list-page/users-list-page.component.html
@@ -21,6 +21,14 @@
           <th i18n>
             Organization
           </th>
+
+          <th class="col--actions">
+            <fa-icon icon="wrench" [fixedWidth]="true"></fa-icon>
+
+            <span class="sr-only" i18n>
+              Actions
+            </span>
+          </th>
         </tr>
       </thead>
 
@@ -35,6 +43,18 @@
 
           <td>
             {{ user.organizationName }}
+          </td>
+
+          <td class="col--actions">
+            <form [formGroup]="deleteForm" (ngSubmit)="deleteUser(user)">
+              <button type="submit" i18n-title title="Delete {{ user.name }}">
+                <fa-icon icon="trash" [fixedWidth]="true"></fa-icon>
+
+                <span class="sr-only" i18n>
+                  Delete {{ user.name }}
+                </span>
+              </button>
+            </form>
           </td>
         </tr>
 

--- a/src/app/pages/users/users-list-page/users-list-page.component.spec.ts
+++ b/src/app/pages/users/users-list-page/users-list-page.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+
+import { LayoutModule } from 'src/app/layout/layout.module';
+
+import { UsersListPageComponent } from './users-list-page.component';
+
+describe('UsersListPageComponent', () => {
+  let component: UsersListPageComponent;
+  let fixture: ComponentFixture<UsersListPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        UsersListPageComponent,
+      ],
+      imports: [
+        FontAwesomeTestingModule,
+        HttpClientTestingModule,
+        LayoutModule,
+        RouterTestingModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UsersListPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/users/users-list-page/users-list-page.component.ts
+++ b/src/app/pages/users/users-list-page/users-list-page.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { NotificationsService } from 'src/app/notifications/notifications.service';
 import { ApiService } from 'src/app/services/api.service';
 
 import { IItem } from 'src/app/interfaces/item';
@@ -15,8 +21,11 @@ export class UsersListPageComponent implements OnInit {
   usersLoaded = false;
   users: User[] = [];
 
+  deleteForm = new FormGroup({});
+
   constructor (
     private apiService: ApiService,
+    private notificationsService: NotificationsService,
   ) { }
 
   ngOnInit (): void {
@@ -25,6 +34,26 @@ export class UsersListPageComponent implements OnInit {
         this.users = result.map((userItem) => new User(userItem));
         this.users.sort((u1, u2) => u1.name.localeCompare(u2.name));
         this.usersLoaded = true;
+      });
+  }
+
+  deleteUser (user: User) {
+    if (!window.confirm($localize `Do you really want to delete the user “${user.name}”?`)) {
+      return;
+    }
+
+    this.apiService.userDelete(user.id)
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          this.notificationsService.error(error.error.message);
+          return throwError(() => new Error(error.error.message));
+        }),
+      ).subscribe((result: any) => {
+        this.users = this.users.filter((u) => {
+          return user.id !== u.id;
+        });
+
+        this.notificationsService.success($localize `The user has been deleted successfully.`);
       });
   }
 }

--- a/src/app/pages/users/users-list-page/users-list-page.component.ts
+++ b/src/app/pages/users/users-list-page/users-list-page.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+
+import { ApiService } from 'src/app/services/api.service';
+
+import { IItem } from 'src/app/interfaces/item';
+
+import { User } from 'src/app/models/user';
+
+@Component({
+  selector: 'app-users-list-page',
+  templateUrl: './users-list-page.component.html',
+  styleUrls: [],
+})
+export class UsersListPageComponent implements OnInit {
+  usersLoaded = false;
+  users: User[] = [];
+
+  constructor (
+    private apiService: ApiService,
+  ) { }
+
+  ngOnInit (): void {
+    this.apiService.userList()
+      .subscribe((result: IItem[]) => {
+        this.users = result.map((userItem) => new User(userItem));
+        this.users.sort((u1, u2) => u1.name.localeCompare(u2.name));
+        this.usersLoaded = true;
+      });
+  }
+}

--- a/src/app/pages/users/users-routing.module.ts
+++ b/src/app/pages/users/users-routing.module.ts
@@ -4,8 +4,15 @@ import { RouterModule, Routes } from '@angular/router';
 import { LoggedInGuard } from 'src/app/guards/logged-in.guard';
 
 import { UsersCreatePageComponent } from './users-create-page/users-create-page.component';
+import { UsersListPageComponent } from './users-list-page/users-list-page.component';
 
 const routes: Routes = [
+  {
+    path: '',
+    title: $localize `Users`,
+    component: UsersListPageComponent,
+    canActivate: [LoggedInGuard],
+  },
   {
     path: 'new',
     title: $localize `New user`,

--- a/src/app/pages/users/users-routing.module.ts
+++ b/src/app/pages/users/users-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { LoggedInGuard } from 'src/app/guards/logged-in.guard';
+
+import { UsersCreatePageComponent } from './users-create-page/users-create-page.component';
+
+const routes: Routes = [
+  {
+    path: 'new',
+    title: $localize `New user`,
+    component: UsersCreatePageComponent,
+    canActivate: [LoggedInGuard],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class UsersRoutingModule { }

--- a/src/app/pages/users/users.module.ts
+++ b/src/app/pages/users/users.module.ts
@@ -9,10 +9,12 @@ import { LayoutModule } from 'src/app/layout/layout.module';
 import { UsersRoutingModule } from './users-routing.module';
 
 import { UsersCreatePageComponent } from './users-create-page/users-create-page.component';
+import { UsersListPageComponent } from './users-list-page/users-list-page.component';
 
 @NgModule({
   declarations: [
     UsersCreatePageComponent,
+    UsersListPageComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/pages/users/users.module.ts
+++ b/src/app/pages/users/users.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { LayoutModule } from 'src/app/layout/layout.module';
+
+import { UsersRoutingModule } from './users-routing.module';
+
+import { UsersCreatePageComponent } from './users-create-page/users-create-page.component';
+
+@NgModule({
+  declarations: [
+    UsersCreatePageComponent,
+  ],
+  imports: [
+    CommonModule,
+    FontAwesomeModule,
+    LayoutModule,
+    UsersRoutingModule,
+    ReactiveFormsModule,
+  ],
+})
+export class UsersModule { }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -92,4 +92,13 @@ export class ApiService {
       },
     });
   }
+
+  public userList () {
+    const typeId = this.settingsService.typeId('users');
+    return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/' + typeId, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -93,6 +93,14 @@ export class ApiService {
     });
   }
 
+  public userDelete (id: number) {
+    return this.http.delete(this.settingsService.backendUrl + '/v1/items/' + id, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
+
   public userList () {
     const typeId = this.settingsService.typeId('users');
     return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/' + typeId, {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -60,4 +60,36 @@ export class ApiService {
       },
     });
   }
+
+  public userCreate (name: string, firstname: string, lastname: string, organizationId: number) {
+    const typeId = this.settingsService.typeId('users');
+
+    const properties = [];
+    if (firstname) {
+      const firstnamePropertyId = this.settingsService.propertyId('userfirstname');
+      properties.push({
+        property_id: firstnamePropertyId,
+        value: firstname,
+      });
+    }
+
+    if (lastname) {
+      const lastnamePropertyId = this.settingsService.propertyId('userlastname');
+      properties.push({
+        property_id: lastnamePropertyId,
+        value: lastname,
+      });
+    }
+
+    return this.http.post(this.settingsService.backendUrl + '/v1/items', {
+      name,
+      organization_id: organizationId,
+      type_id: typeId,
+      properties,
+    }, {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    });
+  }
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -24,7 +24,7 @@ export class ApiService {
   }
 
   public organizationCreate (name: string, parentId: number) {
-    const typeId = this.settingsService.typeId('organization');
+    const typeId = this.settingsService.getTypeIdByInternalname('organization');
     return this.http.post(this.settingsService.backendUrl + '/v1/items', {
       name,
       parent_id: parentId,
@@ -53,7 +53,7 @@ export class ApiService {
   }
 
   public organizationList () {
-    const typeId = this.settingsService.typeId('organization');
+    const typeId = this.settingsService.getTypeIdByInternalname('organization');
     return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/' + typeId, {
       headers: {
         Authorization: 'Bearer ' + this.authService.getToken(),
@@ -62,11 +62,11 @@ export class ApiService {
   }
 
   public userCreate (name: string, firstname: string, lastname: string, organizationId: number) {
-    const typeId = this.settingsService.typeId('users');
+    const typeId = this.settingsService.getTypeIdByInternalname('users');
 
     const properties = [];
     if (firstname) {
-      const firstnamePropertyId = this.settingsService.propertyId('userfirstname');
+      const firstnamePropertyId = this.settingsService.getPropertyIdByInternalname('userfirstname');
       properties.push({
         property_id: firstnamePropertyId,
         value: firstname,
@@ -74,7 +74,7 @@ export class ApiService {
     }
 
     if (lastname) {
-      const lastnamePropertyId = this.settingsService.propertyId('userlastname');
+      const lastnamePropertyId = this.settingsService.getPropertyIdByInternalname('userlastname');
       properties.push({
         property_id: lastnamePropertyId,
         value: lastname,
@@ -102,7 +102,7 @@ export class ApiService {
   }
 
   public userList () {
-    const typeId = this.settingsService.typeId('users');
+    const typeId = this.settingsService.getTypeIdByInternalname('users');
     return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/' + typeId, {
       headers: {
         Authorization: 'Bearer ' + this.authService.getToken(),

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -89,11 +89,11 @@ export class SettingsService {
     return this.configuration.backendUrl;
   }
 
-  public typeId (internalName: string) {
-    return this.typesIndexedByInternalname[internalName]?.id;
+  public getTypeIdByInternalname (internalname: string) {
+    return this.typesIndexedByInternalname[internalname]?.id;
   }
 
-  public propertyId (internalName: string) {
-    return this.propertiesIndexedByInternalname[internalName]?.id;
+  public getPropertyIdByInternalname (internalname: string) {
+    return this.propertiesIndexedByInternalname[internalname]?.id;
   }
 }

--- a/src/locales/messages.en-US.xlf
+++ b/src/locales/messages.en-US.xlf
@@ -39,7 +39,7 @@
         <target state="final">Page not found</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app-routing.module.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
@@ -73,6 +73,14 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">99</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="5248717555542428023" datatype="html">
         <source>Username</source>
@@ -80,6 +88,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4606091236515013460" datatype="html">
@@ -101,13 +113,21 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="86087505018521613" datatype="html">
         <source> The username is required. </source>
         <target state="final"> The username is required. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1431416938026210429" datatype="html">
@@ -123,7 +143,7 @@
         <target state="final"> The password is required. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2454050363478003966" datatype="html">
@@ -187,7 +207,11 @@
         <target state="final"> The name is required. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
-          <context context-type="linenumber">48,50</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1900206707470585659" datatype="html">
@@ -219,11 +243,15 @@
         <target state="final"> Loading of organizations… </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
-          <context context-type="linenumber">91,93</context>
+          <context context-type="linenumber">91</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">61,63</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1437145504608861991" datatype="html">
@@ -271,7 +299,11 @@
         <target state="final"> Name </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">17,19</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4360239040231802726" datatype="html">
@@ -279,7 +311,11 @@
         <target state="final"> Actions </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">24,26</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4168485708389700387" datatype="html">
@@ -289,13 +325,21 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="860771627147100170" datatype="html">
         <source> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </source>
         <target state="final"> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">49,51</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3658263344318351354" datatype="html">
@@ -322,6 +366,162 @@
           <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9220894978749198624" datatype="html">
+        <source>New user</source>
+        <target state="final">New user</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-routing.module.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6940140960884268295" datatype="html">
+        <source> Back to users </source>
+        <target state="final"> Back to users </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">6,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5342432350421167093" datatype="html">
+        <source>First name</source>
+        <target state="final">First name</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3683987907719228878" datatype="html">
+        <source> (optional)</source>
+        <target state="final"> (optional)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3586674587150281199" datatype="html">
+        <source>Last name</source>
+        <target state="final">Last name</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5451710382399122662" datatype="html">
+        <source>Main organization</source>
+        <target state="final">Main organization</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6054105917291240850" datatype="html">
+        <source> The organization is required. </source>
+        <target state="final"> The organization is required. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">105,107</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1525334987774465166" datatype="html">
+        <source>Create a user</source>
+        <target state="final">Create a user</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8304688665352821987" datatype="html">
+        <source> You don’t have the permission to create new users. </source>
+        <target state="final"> You don’t have the permission to create new users. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">130,132</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2219269135978533399" datatype="html">
+        <source>The user has been created successfully.</source>
+        <target state="final">The user has been created successfully.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4555457172864212828" datatype="html">
+        <source>Users</source>
+        <target state="final">Users</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-routing.module.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6721783622639205720" datatype="html">
+        <source> Create a user </source>
+        <target state="final"> Create a user </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7291617695162503736" datatype="html">
+        <source> Organization </source>
+        <target state="final"> Organization </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">21,23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5970104799148685818" datatype="html">
+        <source> Loading of users… </source>
+        <target state="final"> Loading of users… </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">65,67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6890812289295637592" datatype="html">
+        <source> There are no users to show. </source>
+        <target state="final"> There are no users to show. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">72,74</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8332742064218767993" datatype="html">
+        <source>Do you really want to delete the user “<x id="PH" equiv-text="user.name"/>”?</source>
+        <target state="final">Do you really want to delete the user “<x id="PH" equiv-text="user.name"/>”?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2646169429240945264" datatype="html">
+        <source>The user has been deleted successfully.</source>
+        <target state="final">The user has been deleted successfully.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2681586038936504024" datatype="html">
         <source>Home FusionSuite</source>
         <target state="final">Home FusionSuite</target>
@@ -338,12 +538,20 @@
           <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4228319514212568219" datatype="html">
+        <source> Users </source>
+        <target state="final"> Users </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
+          <context context-type="linenumber">18,20</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7507948636555938109" datatype="html">
         <source>Log out</source>
         <target state="final">Log out</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="358462242581945792" datatype="html">

--- a/src/locales/messages.fr-FR.xlf
+++ b/src/locales/messages.fr-FR.xlf
@@ -39,7 +39,7 @@
         <target>Page non trouvée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app-routing.module.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
@@ -73,6 +73,14 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">99</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="5248717555542428023" datatype="html">
         <source>Username</source>
@@ -80,6 +88,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
           <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4606091236515013460" datatype="html">
@@ -101,13 +113,21 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="86087505018521613" datatype="html">
         <source> The username is required. </source>
         <target> Le nom d’utilisateur est obligatoire. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1431416938026210429" datatype="html">
@@ -123,7 +143,7 @@
         <target> Le mot de passe est obligatoire. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">67</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2454050363478003966" datatype="html">
@@ -187,7 +207,11 @@
         <target> Le nom est obligatoire. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
-          <context context-type="linenumber">48,50</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1900206707470585659" datatype="html">
@@ -219,11 +243,15 @@
         <target> Chargement des organisations… </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
-          <context context-type="linenumber">91,93</context>
+          <context context-type="linenumber">91</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">61,63</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1437145504608861991" datatype="html">
@@ -271,7 +299,11 @@
         <target> Nom </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">17,19</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4360239040231802726" datatype="html">
@@ -279,7 +311,11 @@
         <target> Actions </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">24,26</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4168485708389700387" datatype="html">
@@ -289,13 +325,21 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="860771627147100170" datatype="html">
         <source> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </source>
         <target> Supprimer <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
-          <context context-type="linenumber">49,51</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3658263344318351354" datatype="html">
@@ -322,6 +366,162 @@
           <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9220894978749198624" datatype="html">
+        <source>New user</source>
+        <target>Nouvel utilisateur</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-routing.module.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6940140960884268295" datatype="html">
+        <source> Back to users </source>
+        <target> Retour aux utilisateurs </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">6,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5342432350421167093" datatype="html">
+        <source>First name</source>
+        <target>Prénom</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3683987907719228878" datatype="html">
+        <source> (optional)</source>
+        <target> (optionnel)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3586674587150281199" datatype="html">
+        <source>Last name</source>
+        <target>Nom</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5451710382399122662" datatype="html">
+        <source>Main organization</source>
+        <target>Organisation principale</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6054105917291240850" datatype="html">
+        <source> The organization is required. </source>
+        <target> L’organisation est obligatoire. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">105,107</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1525334987774465166" datatype="html">
+        <source>Create a user</source>
+        <target>Créer un utilisateur</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8304688665352821987" datatype="html">
+        <source> You don’t have the permission to create new users. </source>
+        <target> Vous n’avez pas la permission de créer de nouveaux utilisateurs. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">130,132</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2219269135978533399" datatype="html">
+        <source>The user has been created successfully.</source>
+        <target>L’utilisateur a été créé correctement.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4555457172864212828" datatype="html">
+        <source>Users</source>
+        <target>Utilisateurs</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-routing.module.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6721783622639205720" datatype="html">
+        <source> Create a user </source>
+        <target> Créer un utilisateur </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7291617695162503736" datatype="html">
+        <source> Organization </source>
+        <target> Organisation </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">21,23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5970104799148685818" datatype="html">
+        <source> Loading of users… </source>
+        <target> Chargement des utilisateurs… </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">65,67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6890812289295637592" datatype="html">
+        <source> There are no users to show. </source>
+        <target> Il n’y a aucun utilisateur à afficher. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">72,74</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8332742064218767993" datatype="html">
+        <source>Do you really want to delete the user “<x id="PH" equiv-text="user.name"/>”?</source>
+        <target>Êtes-vous sûr de vouloir supprimer l’utilisateur « <x id="PH" equiv-text="user.name"/> » ?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2646169429240945264" datatype="html">
+        <source>The user has been deleted successfully.</source>
+        <target>L’utilisateur a été supprimé correctement.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="2681586038936504024" datatype="html">
         <source>Home FusionSuite</source>
         <target>Accueil FusionSuite</target>
@@ -338,12 +538,20 @@
           <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4228319514212568219" datatype="html">
+        <source> Users </source>
+        <target> Utilisateurs </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
+          <context context-type="linenumber">18,20</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7507948636555938109" datatype="html">
         <source>Log out</source>
         <target>Se déconnecter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="358462242581945792" datatype="html">

--- a/src/locales/messages.xlf
+++ b/src/locales/messages.xlf
@@ -29,14 +29,14 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">3</context>
+          <context context-type="linenumber">3,4</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2275328567992347600" datatype="html">
         <source>Page not found</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app-routing.module.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">37</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/not-found-page/not-found-page.component.html</context>
@@ -61,11 +61,18 @@
           <context context-type="linenumber">9,11</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4228319514212568219" datatype="html">
+        <source> Users </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
+          <context context-type="linenumber">18,20</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="7507948636555938109" datatype="html">
         <source>Log out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/layout/page-menu/page-menu.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="358462242581945792" datatype="html">
@@ -103,23 +110,35 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">99</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">127</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="5248717555542428023" datatype="html">
         <source>Username</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">24,25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4606091236515013460" datatype="html">
         <source>Error:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">41,42</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">66,67</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
@@ -129,33 +148,41 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">76</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">104</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="86087505018521613" datatype="html">
         <source> The username is required. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">42,44</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1431416938026210429" datatype="html">
         <source>Password</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">49,50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5050048058261668004" datatype="html">
         <source> The password is required. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">67,69</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2454050363478003966" datatype="html">
         <source>Login</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/login-page/login-page.component.html</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">74,75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5401867940002169262" datatype="html">
@@ -207,6 +234,10 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-create-page/organizations-create-page.component.html</context>
           <context context-type="linenumber">48,50</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">76,78</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="1900206707470585659" datatype="html">
         <source>Parent organization</source>
@@ -238,6 +269,10 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">61,63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">119,121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1437145504608861991" datatype="html">
@@ -282,12 +317,20 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">17,19</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">17,19</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="4360239040231802726" datatype="html">
         <source> Actions </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">24,26</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">28,30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4168485708389700387" datatype="html">
@@ -296,12 +339,20 @@
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="860771627147100170" datatype="html">
         <source> Delete <x id="INTERPOLATION" equiv-text="{{ organization.name }}"/> </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.html</context>
           <context context-type="linenumber">49,51</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">53,55</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3658263344318351354" datatype="html">
@@ -323,6 +374,145 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/organizations/organizations-list-page/organizations-list-page.component.ts</context>
           <context context-type="linenumber">79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9220894978749198624" datatype="html">
+        <source>New user</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-routing.module.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6940140960884268295" datatype="html">
+        <source> Back to users </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">6,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5342432350421167093" datatype="html">
+        <source>First name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3683987907719228878" datatype="html">
+        <source> (optional)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">46</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3586674587150281199" datatype="html">
+        <source>Last name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5451710382399122662" datatype="html">
+        <source>Main organization</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6054105917291240850" datatype="html">
+        <source> The organization is required. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">105,107</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1525334987774465166" datatype="html">
+        <source>Create a user</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">112</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8304688665352821987" datatype="html">
+        <source> You don’t have the permission to create new users. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.html</context>
+          <context context-type="linenumber">130,132</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2219269135978533399" datatype="html">
+        <source>The user has been created successfully.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-create-page/users-create-page.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4555457172864212828" datatype="html">
+        <source>Users</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-routing.module.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6721783622639205720" datatype="html">
+        <source> Create a user </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">9,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7291617695162503736" datatype="html">
+        <source> Organization </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">21,23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5970104799148685818" datatype="html">
+        <source> Loading of users… </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">65,67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6890812289295637592" datatype="html">
+        <source> There are no users to show. </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.html</context>
+          <context context-type="linenumber">72,74</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8332742064218767993" datatype="html">
+        <source>Do you really want to delete the user “<x id="PH" equiv-text="user.name"/>”?</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.ts</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2646169429240945264" datatype="html">
+        <source>The user has been deleted successfully.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/users/users-list-page/users-list-page.component.ts</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -1,4 +1,5 @@
 @import "variables/colors";
+@import "utilities/cols";
 @import "utilities/flow";
 @import "utilities/wrapper";
 @import "alerts";

--- a/src/theme/utilities/cols.scss
+++ b/src/theme/utilities/cols.scss
@@ -1,0 +1,24 @@
+.cols {
+  display: flex;
+
+  flex-direction: column;
+}
+
+.cols > * {
+  flex: 1;
+}
+
+.cols > * + * {
+  margin-top: 1rem;
+}
+
+@media (min-width: 600px) {
+  .cols {
+    flex-direction: row;
+  }
+
+  .cols > * + * {
+    margin-top: 0;
+    margin-left: 1rem;
+  }
+}


### PR DESCRIPTION
**This PR must be merged after https://github.com/fusionSuite/frontend/pull/31**

Changes proposed in this pull request:

- Add a form to create users (first and last names, username and organization), username is prefilled with first and last names
- Add a page to list and delete users
- Update the French locale
- On a technical aspect, it introduces "models" to manipulate items more easily

How to test the feature manually:

1. Login, go to the "users" page and click on "Create a user"
2. Create a bunch of users
3. Verify that the username is prefilled based on first and last names
4. Go back to the users list and check that users have been created

Known limitations:

- considering the current state of the backend:
  - usernames can be duplicated, and there are no verification of the format (e.g. spaces are allowed)
  - emails and passwords cannot be set yet
  - first and last names are optional
- some code could be refactored with the organizations, but I plan to do it after

List of users:

![Capture d’écran 2022-08-30 à 10 52 00](https://user-images.githubusercontent.com/107053378/187393813-127d7049-4e52-4603-a0bf-4125f79ecf54.png)

Create a user:

![Capture d’écran 2022-08-30 à 10 52 18](https://user-images.githubusercontent.com/107053378/187393859-35813d34-7a79-44b1-95d4-50cd0bcf0327.png)

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [x] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to https://github.com/fusionSuite/FusionSuite/issues/42
