### PR TITLE
[wip] New/refresh token

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -106,7 +106,7 @@ jobs:
       working-directory: ./frontend
       run: |
         cp src/config.sample.json dist/frontend/en-US/config.json
-        sed -i 's#https://backend.example.com#http://localhost/fusionsuite/backend#' dist/frontend/en-US/config.json
+        sed -i 's#https://backend.example.com#http://backend.localhost#' dist/frontend/en-US/config.json
 
     # Configure the Nginx server
     - name: Remove default Nginx configuration

--- a/cypress/ci-nginx.conf
+++ b/cypress/ci-nginx.conf
@@ -13,9 +13,9 @@ server {
 
     add_header      Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header      X-Frame-Options "SAMEORIGIN" always;
-    add_header      Access-Control-Allow-Origin * always;
+    add_header      Access-Control-Allow-Origin 'http://frontend.localhost' always;
     add_header      Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE' always;
-    add_header      Access-Control-Allow-Credentials true always;
+    add_header      Access-Control-Allow-Credentials 'true' always;
     add_header      Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization,Cache-Control,Pragma,Expires' always;
     add_header      Access-Control-Expose-Headers 'X-Total-Count,Content-Range,Link' always;
   }

--- a/src/app/api/v1.ts
+++ b/src/app/api/v1.ts
@@ -38,6 +38,12 @@ export class ApiV1 {
     });
   }
 
+  public postRefreshToken (refreshtoken: string) {
+    return this.http.post(this.settingsService.backendUrl + '/v1/token', {
+      refreshtoken,
+    });
+  }
+
   protected listItems (typeInternalname: string) {
     const typeId = this.settingsService.getTypeIdByInternalname(typeInternalname);
     return this.http.get<IItem[]>(this.settingsService.backendUrl + '/v1/items/type/' + typeId, {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,16 +29,16 @@ import { LayoutModule } from 'src/app/layout/layout.module';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
-import { SettingsService } from './services/settings.service';
-
 import { HomePageComponent } from './pages/home-page/home-page.component';
 import { LoginPageComponent } from './pages/login-page/login-page.component';
 import { NotFoundPageComponent } from './pages/not-found-page/not-found-page.component';
 
 import { NotificationsComponent } from './notifications/notifications.component';
+import { httpInterceptorProviders } from './services/auth.interceptor';
+import { InitappService } from './services/initapp.service';
 
-function initializeApp (settings: SettingsService) {
-  return () => settings.loadConfiguration();
+function initializeApp (initapp: InitappService) {
+  return () => initapp.loadConfiguration();
 }
 
 @NgModule({
@@ -60,10 +60,11 @@ function initializeApp (settings: SettingsService) {
     ReactiveFormsModule,
   ],
   providers: [
+    httpInterceptorProviders,
     {
       provide: APP_INITIALIZER,
       useFactory: initializeApp,
-      deps: [SettingsService],
+      deps: [InitappService],
       multi: true,
     },
   ],

--- a/src/app/pages/login-page/login-page.component.ts
+++ b/src/app/pages/login-page/login-page.component.ts
@@ -26,7 +26,7 @@ import { catchError } from 'rxjs/operators';
 
 import { ApiV1 } from 'src/app/api/v1';
 import { AuthService } from 'src/app/services/auth.service';
-import { SettingsService } from 'src/app/services/settings.service';
+import { InitappService } from 'src/app/services/initapp.service';
 import { FormStatus } from 'src/app/utils/form-status';
 
 @Component({
@@ -54,7 +54,7 @@ export class LoginPageComponent implements OnInit {
   constructor (
     private apiV1: ApiV1,
     private authService: AuthService,
-    private settingsService: SettingsService,
+    private initappService: InitappService,
     private router: Router,
   ) { }
 
@@ -84,9 +84,10 @@ export class LoginPageComponent implements OnInit {
       .subscribe(async (result: any) => {
         // Save the token to use it later
         this.authService.login(result.token);
+        this.authService.storeRefreshToken(result.refreshtoken);
 
         // Load types in settings so we'll be able to manage items
-        await this.settingsService.loadTypes();
+        await this.initappService.loadTypes();
 
         // Reset the form to its initial state
         this.formStatus = 'Initial';

--- a/src/app/services/auth.interceptor.ts
+++ b/src/app/services/auth.interceptor.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HTTP_INTERCEPTORS, HttpErrorResponse, HttpClient } from '@angular/common/http';
+
+import { AuthService } from 'src/app/services/auth.service';
+
+import { Observable, throwError } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+import { SettingsService } from './settings.service';
+
+@Injectable()
+export class HttpRequestInterceptor implements HttpInterceptor {
+  private isRefreshing = false;
+
+  constructor (
+    private authService: AuthService,
+    protected http: HttpClient,
+    private settingsService: SettingsService,
+  ) {}
+
+  intercept (req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    req = req.clone({
+      withCredentials: true,
+    });
+    return next.handle(req).pipe(
+      catchError((error) => {
+        if (
+          error instanceof HttpErrorResponse &&
+          !req.url.includes('auth/signin') &&
+          error.status === 401
+        ) {
+          return this.handle401Error(req, next);
+        }
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  private handle401Error (request: HttpRequest<any>, next: HttpHandler) {
+    if (!this.isRefreshing) {
+      this.isRefreshing = true;
+
+      // Check if the token refreshed by another httpinterceptor instance
+      const reqAuthorization = request.headers.get('Authorization');
+      if (reqAuthorization !== 'Bearer ' + this.authService.getToken()) {
+        request = request.clone({
+          setHeaders: { Authorization: 'Bearer ' + this.authService.getToken() },
+        });
+        return next.handle(request);
+      }
+      // otherwise try refresh the token
+      const refreshToken = this.authService.getRefreshToken();
+      if (this.authService.getToken() !== '' && refreshToken !== '') {
+        return this.http.post(this.settingsService.backendUrl + '/v1/refreshtoken', { token: this.authService.getToken(), refreshtoken: refreshToken }).pipe(
+          switchMap((result: any) => {
+            this.isRefreshing = false;
+            this.authService.login(result.token);
+            this.authService.storeRefreshToken(result.refreshtoken);
+
+            request = request.clone({
+              setHeaders: { Authorization: 'Bearer ' + this.authService.getToken() },
+            });
+
+            return next.handle(request);
+          }),
+          catchError((error) => {
+            this.isRefreshing = false;
+
+            return throwError(() => error);
+          }),
+        );
+      }
+    }
+
+    return next.handle(request);
+  }
+}
+
+export const httpInterceptorProviders = [
+  { provide: HTTP_INTERCEPTORS, useClass: HttpRequestInterceptor, multi: true },
+];

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -61,6 +61,14 @@ export class AuthService {
     }
   }
 
+  public storeRefreshToken (token: string) {
+    window.localStorage.setItem('authentication_refreshtoken', token);
+  }
+
+  public getRefreshToken () {
+    return window.localStorage.getItem('authentication_refreshtoken') || '';
+  }
+
   public logout () {
     this.token = '';
     window.localStorage.removeItem('authentication_token');

--- a/src/app/services/initapp.service.ts
+++ b/src/app/services/initapp.service.ts
@@ -1,0 +1,101 @@
+/**
+ * FusionSuite - Frontend
+ * Copyright (C) 2022 FusionSuite
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+
+import { map, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { IProperty } from 'src/app/interfaces/property';
+import { IType } from 'src/app/interfaces/type';
+
+import { AuthService } from 'src/app/services/auth.service';
+import { SettingsService } from './settings.service';
+
+interface Configuration {
+  backendUrl: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+
+export class InitappService {
+  constructor (
+    private http: HttpClient,
+    private authService: AuthService,
+    public SettingsService: SettingsService,
+  ) { }
+
+  public async loadConfiguration () {
+    await this.http.get<Configuration>('config.json')
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          if (error.status === 404) {
+            // The configuration file is optional, so it's safe to ignore (404)
+            // error here.
+            return of({});
+          } else {
+            return throwError(() => new Error(error.error.message));
+          }
+        }),
+      ).pipe(map((configuration: Configuration | {}) => {
+        // Merge the default configuration with the configuration from the server.
+        this.SettingsService.configuration = {
+          ...this.SettingsService.configuration,
+          ...configuration,
+        };
+      }))
+      .toPromise();
+
+    if (this.authService.isLoggedIn()) {
+      await this.loadTypes();
+    }
+  }
+
+  public loadTypes () {
+    return this.http.get<IType[]>(this.SettingsService.configuration.backendUrl + '/v1/config/types', {
+      headers: {
+        Authorization: 'Bearer ' + this.authService.getToken(),
+      },
+    })
+      .pipe(
+        catchError((error: HttpErrorResponse) => {
+          let errorMessage = error.message;
+          if (error.error.message) {
+            errorMessage = error.error.message;
+          }
+
+          return throwError(() => new Error(errorMessage));
+        }),
+      ).pipe(map((types: IType[]) => {
+        this.SettingsService.resetTypes();
+        this.SettingsService.resetProperties();
+
+        types.forEach((type: IType) => {
+          this.SettingsService.setTypeIndex(type.internalname, type);
+
+          type.properties.forEach((property: IProperty) => {
+            this.SettingsService.setPropertyIndex(property.internalname, property);
+          });
+        });
+      }))
+      .toPromise();
+  }
+}

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -17,15 +17,9 @@
  */
 
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-
-import { map, of, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
 
 import { IProperty } from 'src/app/interfaces/property';
 import { IType } from 'src/app/interfaces/type';
-
-import { AuthService } from 'src/app/services/auth.service';
 
 interface Configuration {
   backendUrl: string;
@@ -35,7 +29,7 @@ interface Configuration {
   providedIn: 'root',
 })
 export class SettingsService {
-  private configuration: Configuration = {
+  public configuration: Configuration = {
     backendUrl: '/api',
   };
 
@@ -43,68 +37,26 @@ export class SettingsService {
   private typesIndexedByInternalname: {[key: string]: IType} = {};
 
   constructor (
-    private http: HttpClient,
-    private authService: AuthService,
   ) { }
-
-  public async loadConfiguration () {
-    await this.http.get<Configuration>('config.json')
-      .pipe(
-        catchError((error: HttpErrorResponse) => {
-          if (error.status === 404) {
-            // The configuration file is optional, so it's safe to ignore (404)
-            // error here.
-            return of({});
-          } else {
-            return throwError(() => new Error(error.error.message));
-          }
-        }),
-      ).pipe(map((configuration: Configuration | {}) => {
-        // Merge the default configuration with the configuration from the server.
-        this.configuration = {
-          ...this.configuration,
-          ...configuration,
-        };
-      }))
-      .toPromise();
-
-    if (this.authService.isLoggedIn()) {
-      await this.loadTypes();
-    }
-  }
-
-  public loadTypes () {
-    return this.http.get<IType[]>(this.configuration.backendUrl + '/v1/config/types', {
-      headers: {
-        Authorization: 'Bearer ' + this.authService.getToken(),
-      },
-    })
-      .pipe(
-        catchError((error: HttpErrorResponse) => {
-          let errorMessage = error.message;
-          if (error.error.message) {
-            errorMessage = error.error.message;
-          }
-
-          return throwError(() => new Error(errorMessage));
-        }),
-      ).pipe(map((types: IType[]) => {
-        this.typesIndexedByInternalname = {};
-        this.propertiesIndexedByInternalname = {};
-
-        types.forEach((type: IType) => {
-          this.typesIndexedByInternalname[type.internalname] = type;
-
-          type.properties.forEach((property: IProperty) => {
-            this.propertiesIndexedByInternalname[property.internalname] = property;
-          });
-        });
-      }))
-      .toPromise();
-  }
 
   get backendUrl () {
     return this.configuration.backendUrl;
+  }
+
+  public resetTypes () {
+    this.typesIndexedByInternalname = {};
+  }
+
+  public resetProperties () {
+    this.propertiesIndexedByInternalname = {};
+  }
+
+  public setTypeIndex (internalname :string, data :any) {
+    this.typesIndexedByInternalname[internalname] = data;
+  }
+
+  public setPropertyIndex (internalname :string, data :any) {
+    this.propertiesIndexedByInternalname[internalname] = data;
   }
 
   public getTypeIdByInternalname (internalname: string) {


### PR DESCRIPTION
Changes proposed in this pull request:

- add http interceptor to renew a new JWT token with refresh token 


How to test the feature manually:

1. wait time after login and go in an another page and it will refresh the token (can wee the http error in console of the browser

Pull request checklist:

- [ ] code is manually tested
- [ ] tests are updated
- [ ] commit messages are relevant
- [ ] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
