### PR TITLE
Update php7.4 to 8.0 because 7.4 is deprecated in the tests.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   end-to-end:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       mariadb:
@@ -26,7 +26,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.0'
 
     - name: Use Node.js 16
       uses: actions/setup-node@v2
@@ -37,7 +37,7 @@ jobs:
     # Setup a Nginx server
     - name: Setup php-fpm
       env:
-        version: '7.4'
+        version: '8.0'
       run: |
         sudo apt-get install php$version-fpm
         sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm
@@ -115,6 +115,12 @@ jobs:
     - name: Copy Nginx config file
       working-directory: ./frontend
       run: sudo cp cypress/ci-nginx.conf /etc/nginx/sites-enabled/fusionsuite.conf
+
+    - name: copy all files to /var/www
+      run: |
+        sudo rm -fr /var/www/*
+        sudo cp -fr ./frontend /var/www/
+        sudo cp -fr ./backend /var/www/
 
     - name: Reload nginx
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     tests:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
         - uses: actions/checkout@v2

--- a/cypress/ci-nginx.conf
+++ b/cypress/ci-nginx.conf
@@ -2,11 +2,11 @@ server {
   listen 80;
   server_name backend.localhost;
 
-  root /home/runner/work/frontend/frontend/backend/public;
+  root /var/www/backend/public;
   index index.html index.php;
 
   location / {
-    fastcgi_pass    unix:/run/php/php7.4-fpm.sock;
+    fastcgi_pass    unix:/run/php/php8.0-fpm.sock;
 
     fastcgi_param   SCRIPT_FILENAME $document_root/index.php$fastcgi_script_name;
     include         fastcgi_params;
@@ -25,7 +25,7 @@ server {
   listen 80;
   server_name frontend.localhost;
 
-  root /home/runner/work/frontend/frontend/frontend/dist/frontend/en-US;
+  root /var/www/frontend/dist/frontend/en-US;
   index index.html;
 
   location / {


### PR DESCRIPTION
Changes proposed in this pull request:

- in tests, update PHP 7.4 to 8.0 because deprecated (used to setup the backend)
-
-

How to test the feature manually:

1.
2.
3.

Pull request checklist:

- [x] code is manually tested
- [x] tests are updated
- [ ] commit messages are relevant
- [x] documentation is updated (including code comments, commit messages…)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._

Related to #
